### PR TITLE
Provide more info about deprecated function

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -179,6 +179,8 @@ main();
 ### `snaptrade.accountInformation.getAllUserHoldings`<a id="snaptradeaccountinformationgetalluserholdings"></a>
 ![Deprecated](https://img.shields.io/badge/deprecated-yellow)
 
+⚠️ This function is deprecated. Instead, use [`snaptrade.accountInformation.getUserHoldings`](#snaptradeaccountinformationgetuserholdings) for each `accountId`.
+
 Lists balances, positions and orders for the specified account. The data returned is similar to
 the data returned over the more fine-grained **positions**, **orders** and **balances** endpoints.
 


### PR DESCRIPTION
The little "Deprecated" icon is easy to miss, and it doesn't provide any info about which function should be used instead.

This PR draws more attention to the fact that this function is deprecated and provides a suggestion about what function to use instead.