### PR TITLE
In example code, replace deprecated function

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -131,14 +131,14 @@ async function main() {
   if (!("redirectURI" in data)) throw Error("Should have gotten redirect URI");
   console.log("redirectURI:", data.redirectURI);
 
-  // 5) Obtaining account holdings data
-  const holdings = (
-    await snaptrade.accountInformation.getAllUserHoldings({
+  // 5) Obtaining list of user's account
+  const accountList = (
+    await snaptrade.accountInformation.listUserAccounts({
       userId,
       userSecret,
     })
   ).data;
-  console.log("holdings:", holdings);
+  console.log("accounts:", accountList);
 
   // 6) Deleting a user
   const deleteResponse = (

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -131,7 +131,7 @@ async function main() {
   if (!("redirectURI" in data)) throw Error("Should have gotten redirect URI");
   console.log("redirectURI:", data.redirectURI);
 
-  // 5) Obtaining list of user's account
+  // 5) Obtaining list of user's accounts
   const accountList = (
     await snaptrade.accountInformation.listUserAccounts({
       userId,


### PR DESCRIPTION
`getAllUserHoldings` is deprecated, so it should not be used in the example code.

Use `listUserAccounts` in the example instead. This function is similar to `getAllUserHoldings` in that it only requires userId and userSecret. So it makes sense that this would be chronologically first in a series of other API calls.

The example could be expanded further by then using the list of accounts to make additional API calls, but for now, we have a minimal example that does not use any deprecated functions.