### PR TITLE
Add new OptionBrokerageSymbol to Options holdings endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -2301,7 +2301,7 @@ components:
       type: object
       properties:
         symbol:
-          $ref: "#/components/schemas/BrokerageSymbol"
+          $ref: "#/components/schemas/OptionBrokerageSymbol"
         price:
           $ref: "#/components/schemas/Price"
         units:
@@ -3506,6 +3506,34 @@ components:
           allOf:
             - $ref: "#/components/schemas/OptionsSymbol"
           nullable: true
+    OptionBrokerageSymbol:
+      description: Option Brokerage symbol
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        description:
+          type: string
+          example: SPY CALL 7/17 200
+        option_symbol:
+          allOf:
+            - $ref: "#/components/schemas/OptionsSymbol"
+          nullable: true
+        security_type:
+          $ref: "#/components/schemas/SecurityType"
+        listing_exchange:
+          type: string
+          example: OPRA
+        local_id:
+          type: string
+          example: "3291231"
+          nullable: true
+        is_quotable:
+          type: boolean
+          example: true
+        is_tradable:
+          type: boolean
+          example: true
     PositionSymbol:
       description: Symbol returned in position object
       type: object


### PR DESCRIPTION
Create a new `OptionBrokerageSymbol` to use in the api docs for options holdings. Currently we display an example response that includes common stock symbols as seen in the main holdings endpoint.

Note: I added all fields currently returned to me on the Options holdings API today for an option I hold at Robinhood:

```
[
  {
    "symbol": {
      "id": "048c6d72-3c94-4487-a5ff-9569c3b9fb1e",
      "description": "",
      "option_symbol": {...},
      "local_id": "",
      "security_type": {},
      "listing_exchange": {},
      "is_quotable": true,
      "is_tradable": true
    },
    "price": 1.6,
    "units": 3,
    "currency": null,
    "average_purchase_price": 172
  }
]
```

Tested locally with OpenAPI preview vscode extension.