### PR TITLE
Hide the option trading endpoints from docs

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -78,6 +78,14 @@ portal:
       get: true
     /performance/custom:
       get: true
+    /accounts/{accountId}/optionsChain:
+      get: true
+    /accounts/{accountId}/optionStrategy:
+      post: true
+    /accounts/{accountId}/optionStrategy/{optionStrategyId}:
+      get: true
+    /accounts/{accountId}/optionStrategy/{optionStrategyId}/execute:
+      post: true
   hideSecurity:
     - name: PartnerSignature
     - name: PartnerTimestamp


### PR DESCRIPTION
None of these are being used today. Instead of adding doc references to them, let's hide them for now and revisit when we support option trading 