### PR TITLE
Doc: Reorder doc sections

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -11,6 +11,8 @@ order:
     operations:
       - path: /accounts
         method: get
+  - tag: Options
+  - tag: Transactions And Reporting
   - tag: Trading
     operations:
       - Trading_getUserAccountQuotes
@@ -91,8 +93,6 @@ portal:
     - name: PartnerTimestamp
 filterTags:
   - Webhooks
-  - Development Tools
-  - Custom Brokerage API Credentials
 filterModels:
   - SnapTradePartnerAPICredential
   - WebhookBase


### PR DESCRIPTION
Put `Options` and `Transactions` before `Trading` and `Reference Data`.

I'd also like to merge `Options` and `Transactions` into `Account Info` but that's a bigger change since it'll be a breaking change in the SDKs: https://passiv.slack.com/archives/C04E71257MY/p1724211804487639