### PR TITLE
Hide some operations from Reference Data

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -90,6 +90,20 @@ portal:
       get: true
     /accounts/{accountId}/optionStrategy/{optionStrategyId}/execute:
       post: true
+    /snapTrade/partners:
+      get: true
+    /brokerageAuthorizationTypes:
+      get: true
+    /currencies:
+      get: true
+    /currencies/rates:
+      get: true
+    /currencies/rates/{currencyPair}:
+      get: true
+    /exchanges:
+      get: true
+    /securityTypes:
+      get: true
   hideSecurity:
     - name: PartnerSignature
     - name: PartnerTimestamp


### PR DESCRIPTION
Hiding these ones and if people need them, we can take the opportunity to understand their usecase. I'm leaving the symbol related ones behind since those would be needed for trading.

![image](https://github.com/user-attachments/assets/dbb91028-7910-4f39-85c1-33e5346b8f8e)
