### PR TITLE
Make Typescript SDK Web Worker Compatible

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snaptrade-typescript-sdk",
-  "version": "9.0.60",
+  "version": "9.0.61",
   "description": "Client for SnapTrade",
   "author": "Konfig",
   "engines": {
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "axios": "1.7.4"
+    "axios": "1.7.9"
   },
   "resolutions": {
     "semver": "^7.5.2",

--- a/sdks/typescript/requestAfterHook.ts
+++ b/sdks/typescript/requestAfterHook.ts
@@ -25,14 +25,14 @@ async function computeHmacSha256(
     const encoder = new TextEncoder();
     const keyBuffer = encoder.encode(key);
     const msgBuffer = encoder.encode(message);
-    const cryptoKey = await window.crypto.subtle.importKey(
+    const cryptoKey = await globalThis.crypto.subtle.importKey(
       "raw",
       keyBuffer,
       { name: "HMAC", hash: "SHA-256" },
       false,
       ["sign"]
     );
-    const signature = await window.crypto.subtle.sign(
+    const signature = await globalThis.crypto.subtle.sign(
       "HMAC",
       cryptoKey,
       msgBuffer


### PR DESCRIPTION
The typescript SDK currently errors out in 2 places when running on a Web Worker (e.g. Cloudflare Workers):

- When `window` is referenced, in this case when the `window.crypto` module is used.
  - Use `globalThis` instead, which is the same thing but compatible with both browsers and Web Workers.
- When using axios v1.7.4 (https://github.com/axios/axios/issues/6565)
  - Up the version of axios to v1.7.5 or higher. I've set it to the latest version (1.7.9).

With these two changes, the SDK can be used on Web Workers. Closes #268.