### PR TITLE
Enhance crypto trading documentation clarity

### DIFF
--- a/docs/crypto-trading.md
+++ b/docs/crypto-trading.md
@@ -2,9 +2,9 @@
 
 SnapTrade supports specialized crypto-specific trading endpoints for some exchanges such as Kraken, Binance and Coinbase. We recommend that you limit trade requests to 1 trade per second per account to maximize the chances that they are all executed without error.
 
-Trading crypto works with tradable asset pairs. That means you trade a `base` asset (such as crypto or fiat currency) for a `quote` asset (which can also be a crypto or fiat currency), with the direction being determined by the action (eg: BUY or SELL).
+Trading crypto works with tradable asset pairs represented by `BASE-QUOTE`. That means you trade between a `base` asset (such as crypto or fiat currency) and a `quote` asset (which can also be a crypto or fiat currency), with the direction being determined by the action (eg: BUY or SELL). When buying, base is what is being bought and quote is what is being sold or spent. When selling, base is what is being sold and quote is what is being received.
 
-Here is an example payload that would execute a trade buying ETH with EUR. Don't worry if it's a bit hard to understand at first, the rest of the doc should provide you with the right context.
+Here is an example payload that would execute a trade buying 0.01 ETH (base) with EUR (quote). Don't worry if it's a bit hard to understand at first, the rest of the doc should provide you with the right context.
 
 ```json
 {


### PR DESCRIPTION
Clarified the explanation of tradable asset pairs and provided specific examples of base and quote assets in crypto trading.