### PR TITLE
Fix inconsistent variable naming in connection messaging docs

### DIFF
--- a/docs/connection-messaging.md
+++ b/docs/connection-messaging.md
@@ -21,7 +21,7 @@ Accessing messages through JavaScript is slightly more complex but still easy to
 ```js
 window.addEventListener(
   "message",
-  (event) => {
+  (e) => {
     if (
       e.data &&
       (e.origin === "https://app.snaptrade.com" ||
@@ -34,7 +34,7 @@ window.addEventListener(
       } else if (data.status === "ERROR") {
         const { errorCode, statusCode, detail } = data;
         // Handle error message
-      } else if (e.data === "CLOSED") {
+      } else if (data === "CLOSED") {
         // Handle closed message
       }
     }


### PR DESCRIPTION
## Summary
- Fixed callback parameter naming inconsistency in the JavaScript `addEventListener` code example in `docs/connection-messaging.md`. The parameter was declared as `event` but referenced as `e` throughout the function body, which would cause a runtime error.
- Changed `e.data === "CLOSED"` to `data === "CLOSED"` to use the existing local `data` variable, consistent with how the other conditions in the same block reference `data.status`.

## Test plan
- [ ] Verify the code example in `docs/connection-messaging.md` uses consistent variable names
- [ ] Confirm the callback parameter `e` matches all references in the function body

🤖 Generated with [Claude Code](https://claude.com/claude-code)