### PR TITLE
Hide getUserHoldings endpoint from docs

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -167,6 +167,8 @@ portal:
       get: true
     /authorizations/{authorizationId}:
       delete: true
+    /accounts/{accountId}/holdings:
+      get: true
   hideSecurity:
     - name: PartnerSignature
     - name: PartnerTimestamp


### PR DESCRIPTION
## Summary
- Add `/accounts/{accountId}/holdings` (GET) to `konfig.yaml` `hideOperations` so the `getUserHoldings` endpoint is excluded from docs.snaptrade.com.

## Test plan
- [ ] Verify endpoint no longer renders on docs.snaptrade.com after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)