### PR TITLE
Mark listBrokerageAuthorizationAccounts endpoint as beta

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -118,6 +118,8 @@ portal:
       get: true
     /accounts/{accountId}/balanceHistory:
       get: true
+    /authorizations/{authorizationId}/accounts:
+      get: true
   hideOperations:
     /activities:
       get: true


### PR DESCRIPTION
## Summary
- Adds `/authorizations/{authorizationId}/accounts` (GET) to `betaOperations` in `konfig.yaml` so the endpoint shows a beta pill on the docs page.

## Test plan
- [ ] Verify the beta pill renders on https://docs.snaptrade.com/reference/Connections/Connections_listBrokerageAuthorizationAccounts after publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)