### PR TITLE
Hide listUserAccounts endpoint from docs

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -173,6 +173,8 @@ portal:
       delete: true
     /accounts/{accountId}/holdings:
       get: true
+    /accounts:
+      get: true
   hideSecurity:
     - name: PartnerSignature
     - name: PartnerTimestamp


### PR DESCRIPTION
## Summary
- Hides the deprecated `GET /accounts` (`AccountInformation_listUserAccounts`) endpoint from the docs by adding it to `hideOperations` in `konfig.yaml`.

## Test plan
- [ ] Verify the endpoint no longer appears at https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_listUserAccounts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)