### PR TITLE
docs: replace deprecated account endpoint references

### DIFF
--- a/docs/filtering-accounts-by-category.md
+++ b/docs/filtering-accounts-by-category.md
@@ -15,7 +15,7 @@ Every account returned by SnapTrade includes an `account_category` field that no
 | `LOC` | Line of credit account (for example, loans or credit cards). |
 | `null` | Category could not be determined (brokerage did not return a recognizable type). Treat as an investment account so legitimate brokerage accounts are not accidentally hidden from trading and holdings flows. |
 
-The field is returned from both :api[AccountInformation_listUserAccounts] and :api[AccountInformation_getUserAccountDetails].
+The field is returned from both :api[Connections_listBrokerageAuthorizationAccounts] and :api[AccountInformation_getUserAccountDetails]. If a user has multiple connections, call :api[Connections_listBrokerageAuthorizations] first, then call :api[Connections_listBrokerageAuthorizationAccounts] for each connection.
 
 ## The `raw_type` Field
 
@@ -28,10 +28,24 @@ Use `raw_type` when you need finer-grained distinctions than `account_category` 
 ### Node.js / TypeScript
 
 ```ts
-const { data: accounts } = await snaptrade.accountInformation.listUserAccounts({
+const { data: connections } = await snaptrade.connections.listBrokerageAuthorizations({
   userId,
   userSecret,
 });
+
+const accounts = (
+  await Promise.all(
+    connections
+      .filter((connection) => connection.id)
+      .map((connection) =>
+        snaptrade.connections.listBrokerageAuthorizationAccounts({
+          authorizationId: connection.id!,
+          userId,
+          userSecret,
+        })
+      )
+  )
+).flatMap((response) => response.data);
 
 const investmentAccounts = accounts.filter(
   (a) => a.account_category === "INVESTMENT" || a.account_category === null
@@ -41,10 +55,20 @@ const investmentAccounts = accounts.filter(
 ### Python
 
 ```python
-accounts = snaptrade.account_information.list_user_accounts(
+connections = snaptrade.connections.list_brokerage_authorizations(
     user_id=user_id,
     user_secret=user_secret,
 ).body
+
+accounts = []
+for connection in connections:
+    accounts.extend(
+        snaptrade.connections.list_brokerage_authorization_accounts(
+            authorization_id=connection["id"],
+            user_id=user_id,
+            user_secret=user_secret,
+        ).body
+    )
 
 investment_accounts = [
     a for a in accounts
@@ -55,7 +79,8 @@ investment_accounts = [
 ### cURL
 
 ```bash
-curl 'https://api.snaptrade.com/api/v1/accounts?userId=...&userSecret=...' \
+# Replace <authorizationId> with an id returned by /authorizations.
+curl 'https://api.snaptrade.com/api/v1/authorizations/<authorizationId>/accounts?userId=...&userSecret=...' \
   | jq '[.[] | select(.account_category == "INVESTMENT" or .account_category == null)]'
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ Once you have a connected `account`, you are ready to move on to pulling account
 
 When you have at least one connected `account` and want to start making use of the `positions`, you will first need to get the `accountId`.
 
-1. You can find the `accountId` anywhere over the API where the `account` object is returned. In this example, use the :api[AccountInformation_listUserAccounts] endpoint to get the `accountId` of the account you wish to pull `positions` for.
+1. You can find the `accountId` anywhere over the API where the `account` object is returned. In this example, call :api[Connections_listBrokerageAuthorizations] to list the user's connections, then call :api[Connections_listBrokerageAuthorizationAccounts] for the relevant connection to get the `accountId` of the account you wish to pull `positions` for.
 2. With the `accountId`, call :api[AccountInformation_getUserAccountPositions]. This will return a list of positions in the specified account.
 
 Once you have `positions` returned, you’re able to make use of the data in analysis, monitoring, or another use-case you might be interested in. Other core endpoints for retrieving account information include :api[AccountInformation_getUserAccountBalance] and :api[AccountInformation_getUserAccountOrders].

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -16,7 +16,7 @@ Webhooks:
 - [ACCOUNT_HOLDINGS_UPDATED](https://docs.snaptrade.com/docs/webhooks#webhooks-account_holdings_updated) will be sent once per day when holdings are updated (regardless of if data changes or not). This is only really helpful for Daily data since Pay as you Go / Real-time plans will update brokerage data with each request.
 
 API Account Status:
-- [List accounts endpoint](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_listUserAccounts) will return a `sync_status` object which will tell you when the daily sync last ran for holdings, as well as the last day that transactions **have been fully synced** (transactions have been pulled from 00:00 to 23:59)
+- [List accounts for a connection endpoint](https://docs.snaptrade.com/reference/Connections/Connections_listBrokerageAuthorizationAccounts) will return a `sync_status` object for each account in the connection. This tells you when the daily sync last ran for holdings, as well as the last day that transactions **have been fully synced** (transactions have been pulled from 00:00 to 23:59). If a user has multiple connections, first call :api[Connections_listBrokerageAuthorizations], then call :api[Connections_listBrokerageAuthorizationAccounts] for each connection.
   ```
   "sync_status": {
       "transactions": {


### PR DESCRIPTION
### Motivation
- Remove references to the deprecated user-scoped `/accounts` endpoints and replace them with the connection-scoped account listing flow so docs guide integrators to the supported APIs for multi-connection users.

### Description
- Replace references to `AccountInformation_listUserAccounts` with the connection-scoped `Connections_listBrokerageAuthorizationAccounts` flow across docs. 
- Update `docs/getting-started.md` to instruct developers to call `Connections_listBrokerageAuthorizations` then `Connections_listBrokerageAuthorizationAccounts` to obtain `accountId`.
- Update `docs/syncing.md` to reference the connection-scoped `Connections_listBrokerageAuthorizationAccounts` for `sync_status` information and add guidance for multi-connection users.
- Update `docs/filtering-accounts-by-category.md` to change examples for TypeScript, Python, and cURL to list connections first and then list accounts per connection (replace direct `/accounts` and corresponding SDK calls with `connections.listBrokerageAuthorizations` + `connections.listBrokerageAuthorizationAccounts`).

### Testing
- Ran a repo scan for deprecated operation IDs and literal deprecated paths (grep/regex and a Python script scanning `docs`), which reported no remaining references to the targeted deprecated endpoints after changes, and the checks succeeded.
- Verified the updated docs files (`docs/getting-started.md`, `docs/syncing.md`, `docs/filtering-accounts-by-category.md`) contain the new `Connections_listBrokerageAuthorizations` / `Connections_listBrokerageAuthorizationAccounts` flow and updated TypeScript/Python/cURL examples by inspecting diffs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a048f16167c8328b159ec9d56772792)