### PR TITLE
Add MCP server documentation for connector store submissions

### DIFF
--- a/docs/connector-privacy.md
+++ b/docs/connector-privacy.md
@@ -1,0 +1,73 @@
+# SnapTrade Connector Privacy Notice
+
+This notice explains how the SnapTrade MCP server (the "connector") handles data when you connect SnapTrade to an AI assistant such as Claude or ChatGPT. It supplements the [SnapTrade Privacy Policy](https://snaptrade.com/privacy-policy), which governs SnapTrade's services overall and applies in full. SnapTrade is operated by Passiv Inc.
+
+The connector is **read-only**: it can retrieve your account data and generate a link to connect a new brokerage, but it cannot place trades, move money, or change account settings.
+
+## What data the connector accesses
+
+When your AI assistant calls a connector tool in response to your prompt, the connector retrieves the following categories of data from SnapTrade and returns them to your assistant:
+
+- **Connections** — the list of brokerages you have connected through SnapTrade and connection metadata such as institution name and connection status.
+- **Account details** — account type, institution name, total account value, and sync status.
+- **Balances** — cash balances and buying power, including per-currency balances.
+- **Positions and holdings** — the securities held in your accounts, with quantities and market values.
+- **Orders** — open, filled, cancelled, and pending orders, including order history and individual order details.
+- **Account activity** — historical transactions such as deposits, withdrawals, dividends, fees, buys, and sells.
+- **Reference data** — currencies, exchange rates, stock exchanges, security types, and symbol lookups. This data is not specific to you.
+
+The connector accesses this data **on demand**, only in direct response to a prompt you make through your AI assistant. It does not collect or retrieve data proactively.
+
+## What the connector does not access
+
+- The connector never exposes your SnapTrade `userId` or `userSecret` to the AI assistant. These partner-level identifiers are stripped from every request before it reaches the assistant.
+- The connector never accesses your brokerage login credentials or passwords.
+- The connector cannot place trades, transfer funds, or change account settings. Access is limited to read-only scope.
+
+## How the connector uses data
+
+The connector is a thin protocol adapter. It uses the data it retrieves solely to fulfill the request you made through your AI assistant, passing the response back to the assistant that asked for it.
+
+SnapTrade does not use connector data for advertising or profiling, and does not use it to train AI models.
+
+## Data storage and retention
+
+The connector is stateless. It does not maintain its own long-term store of your account data — each tool call retrieves data from the SnapTrade Partner API and returns it to your assistant.
+
+Retention of the underlying account data that SnapTrade holds is governed by the [SnapTrade Privacy Policy](https://snaptrade.com/privacy-policy). OAuth access tokens issued to your AI assistant are short-lived and scoped to `read`. Operational logs may be retained for security, reliability, and troubleshooting in line with SnapTrade's standard practices.
+
+## Third-party sharing
+
+When a connector tool returns data, that data is delivered to the AI provider you chose to use — Anthropic for Claude, or OpenAI for ChatGPT. How those providers handle the data is governed by their own privacy policies:
+
+- [Anthropic Privacy Policy](https://www.anthropic.com/legal/privacy)
+- [OpenAI Privacy Policy](https://openai.com/policies/privacy-policy/)
+
+SnapTrade does not sell your personal data. For information on SnapTrade's service providers and other data sharing, see the [SnapTrade Privacy Policy](https://snaptrade.com/privacy-policy).
+
+## Data minimization
+
+The connector is designed to access the minimum data needed to answer your prompts:
+
+- It requests only `read` scope — it cannot write to your accounts.
+- It exposes only a curated set of read-only endpoints, not the full SnapTrade API.
+- It returns data only in direct response to a prompt. Nothing is collected "just in case."
+- Partner-level identifiers and credentials are removed from every request before the AI assistant sees it.
+
+## Revoking access
+
+You can revoke a connector's access at any time from the SnapTrade dashboard under **Settings → Connected apps**. Revoking access immediately invalidates the AI assistant's token. Revoking connector access does not disconnect your brokerages — your SnapTrade connections remain intact. See [SnapTrade MCP Server](https://docs.snaptrade.com/docs/mcp-server) for more on managing access.
+
+## Contact
+
+For privacy or data questions, contact `support@snaptrade.com`. For security vulnerability reports, contact `security@snaptrade.com`. SnapTrade is operated by Passiv Inc.
+
+---
+
+## Related
+
+- [SnapTrade Privacy Policy](https://snaptrade.com/privacy-policy)
+- [SnapTrade Terms and Conditions](https://snaptrade.com/terms-and-conditions)
+- [SnapTrade Security](https://snaptrade.com/security)
+- [SnapTrade Application Compliance Policy](https://snaptrade.com/compliance-policy)
+- [SnapTrade MCP Server](https://docs.snaptrade.com/docs/mcp-server)

--- a/docs/connector-privacy.md
+++ b/docs/connector-privacy.md
@@ -14,7 +14,7 @@ When your AI assistant calls a connector tool in response to your prompt, the co
 - **Positions and holdings** — the securities held in your accounts, with quantities and market values.
 - **Orders** — open, filled, cancelled, and pending orders, including order history and individual order details.
 - **Account activity** — historical transactions such as deposits, withdrawals, dividends, fees, buys, and sells.
-- **Reference data** — currencies, exchange rates, stock exchanges, security types, and symbol lookups. This data is not specific to you.
+- **Reference data** — currencies, exchange rates, stock exchanges, and security types. This data is not specific to you.
 
 The connector accesses this data **on demand**, only in direct response to a prompt you make through your AI assistant. It does not collect or retrieve data proactively.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,3 +147,4 @@ The order will now show over the :api[AccountInformation_getUserAccountOrders] e
 
 - To get started with Webhooks, see [Webhooks](https://docs.snaptrade.com/docs/webhooks)
 - To get started with implementing the SnapTrade Connection Portal, see [Methods to Integrate the Connection Portal into Your Application](https://docs.snaptrade.com/docs/implement-connection-portal)
+- To let your users access their data through AI assistants like Claude and ChatGPT, see [SnapTrade MCP Server](https://docs.snaptrade.com/docs/mcp-server)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -8,6 +8,12 @@ The MCP server is available at `https://mcp.snaptrade.com/mcp`.
 The MCP server is **read-only**. It can retrieve account data and generate a link to connect a new brokerage, but it cannot place trades, move money, or change account settings. For programmatic access to the full SnapTrade API, including trading, see [Getting Started with SnapTrade](https://docs.snaptrade.com/docs/getting-started).
 :::
 
+## Before you begin
+
+The SnapTrade MCP server is for **SnapTrade Personal** users — individuals who connect and manage their own brokerage accounts with SnapTrade. It is not used with SnapTrade developer (partner) API keys.
+
+To use the connector, you'll need a free SnapTrade Personal account. If you don't have one yet, sign up at [SnapTrade Personal](https://www.mysnaptrade.com) and link at least one brokerage account before adding the connector to your AI assistant.
+
 ## What you can do with it
 
 With the SnapTrade connector enabled, an AI assistant can:
@@ -62,6 +68,8 @@ For details on what data the connector accesses and how it is handled, see the [
 4. Set the authentication method to **OAuth** and confirm you trust the application.
 5. Click **Create**, then complete the OAuth login flow with SnapTrade and approve **read** access.
 6. After you approve, the SnapTrade tools become available in your chats.
+
+> Note: ChatGPT Developer mode and custom connectors are available on ChatGPT for web, not the desktop app — complete this setup at [chatgpt.com](https://chatgpt.com).
 
 > Note: Once the SnapTrade app is approved in the ChatGPT app directory, users can add it directly from the directory without enabling Developer mode.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ The MCP server is **read-only**. It can retrieve account data and generate a lin
 
 The SnapTrade MCP server is for **SnapTrade Personal** users — individuals who connect and manage their own brokerage accounts with SnapTrade. It is not used with SnapTrade developer (partner) API keys.
 
-To use the connector, you'll need a free SnapTrade Personal account. If you don't have one yet, sign up at [SnapTrade Personal](https://www.mysnaptrade.com) and link at least one brokerage account before adding the connector to your AI assistant.
+To use the connector, you'll need a free SnapTrade Personal account. If you don't have one yet, sign up at the [SnapTrade Dashboard](https://dashboard.snaptrade.com/signup) and link at least one brokerage account before adding the connector to your AI assistant.
 
 ## What you can do with it
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -84,7 +84,7 @@ Once the connector is enabled, a user can ask their assistant questions like:
 
 ## Available tools
 
-The connector exposes 21 tools. All are read-only except `request_connection_link`, which generates a connection link for the user to open.
+The connector exposes 18 tools. All are read-only except `request_connection_link`, which generates a connection link for the user to open.
 
 **Connections**
 
@@ -97,10 +97,8 @@ The connector exposes 21 tools. All are read-only except `request_connection_lin
 - `AccountInformation_getUserAccountBalance` — cash balances and buying power
 - `AccountInformation_getAllAccountPositions` — positions and holdings for an account
 - `AccountInformation_getAccountBalanceHistory` — historical account balances
-- `AccountInformation_getUserAccountOrders` — orders for an account
-- `AccountInformation_getUserAccountOrdersV2` — orders for an account (v2)
-- `AccountInformation_getUserAccountRecentOrders` — recent orders for an account
-- `AccountInformation_getUserAccountRecentOrdersV2` — recent orders for an account (v2)
+- `AccountInformation_getUserAccountOrdersV2` — orders for an account
+- `AccountInformation_getUserAccountRecentOrdersV2` — recent orders for an account
 - `AccountInformation_getUserAccountOrderDetailV2` — details for a single order
 - `AccountInformation_getAccountActivities` — historical account activity such as deposits, dividends, and fees
 
@@ -111,7 +109,6 @@ The connector exposes 21 tools. All are read-only except `request_connection_lin
 - `ReferenceData_getCurrencyExchangeRatePair` — exchange rate for a specific currency pair
 - `ReferenceData_getSecurityTypes` — supported security types
 - `ReferenceData_getStockExchanges` — supported stock exchanges
-- `ReferenceData_getSymbolsByTicker` — look up a symbol by ticker
 - `ReferenceData_getPartnerInfo` — brokerages and data access available to the connector
 
 **Connection helpers**

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,134 @@
+# SnapTrade MCP Server
+
+SnapTrade offers a hosted [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants like Claude and ChatGPT securely read a user's connected brokerage data through natural-language prompts. Once a user adds SnapTrade as a connector, they can ask their assistant about their balances, positions, orders, and account activity in plain language.
+
+The MCP server is available at `https://mcp.snaptrade.com/mcp`.
+
+:::info
+The MCP server is **read-only**. It can retrieve account data and generate a link to connect a new brokerage, but it cannot place trades, move money, or change account settings. For programmatic access to the full SnapTrade API, including trading, see [Getting Started with SnapTrade](https://docs.snaptrade.com/docs/getting-started).
+:::
+
+## What you can do with it
+
+With the SnapTrade connector enabled, an AI assistant can:
+
+- List the brokerages a user is connected to and the accounts under each connection
+- Retrieve account details, balances, and buying power
+- Retrieve positions and holdings across accounts
+- Review orders, recent orders, and order details
+- Review historical account activity such as deposits, dividends, and fees
+- Look up reference data such as currencies, exchange rates, stock exchanges, and security types
+- Generate a one-time link the user can open to connect a new brokerage
+
+## How it works
+
+The MCP server is a thin protocol adapter in front of the SnapTrade Partner API. AI assistants speak MCP; SnapTrade exposes a REST API. The MCP server translates between the two and forwards each request to the same endpoints SnapTrade partners already use.
+
+```
+AI assistant  →  SnapTrade MCP server  →  SnapTrade Partner API  →  User's brokerages
+```
+
+No new data surface is introduced — the connector exposes a curated, read-only subset of existing SnapTrade endpoints.
+
+## Authentication and security
+
+The connector uses the OAuth 2.0 authorization code grant with PKCE. When a user adds the connector, their AI assistant registers itself automatically using [Dynamic Client Registration (RFC 7591)](https://www.rfc-editor.org/rfc/rfc7591). The user is then redirected to SnapTrade to log in and approve access. Tokens issued to the assistant are scoped to `read`, and the MCP server validates every request using [token introspection (RFC 7662)](https://www.rfc-editor.org/rfc/rfc7662) against SnapTrade's authorization server.
+
+:::info
+The AI assistant never sees a user's SnapTrade `userId` or `userSecret`, and never sees brokerage login credentials. It only receives a short-lived, read-scoped access token. SnapTrade resolves the user from that token.
+:::
+
+Clients can discover the connector's OAuth configuration at these endpoints:
+
+- `https://mcp.snaptrade.com/.well-known/oauth-protected-resource/mcp`
+- `https://api.snaptrade.com/.well-known/oauth-authorization-server/mcp`
+
+For details on what data the connector accesses and how it is handled, see the [SnapTrade Connector Privacy Notice](https://docs.snaptrade.com/docs/connector-privacy). For SnapTrade's overall security posture, see [snaptrade.com/security](https://snaptrade.com/security).
+
+## Set up the connector in Claude
+
+1. In Claude, go to **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Enter the MCP server URL: `https://mcp.snaptrade.com/mcp`.
+4. Claude redirects you to SnapTrade. Log in and approve **read** access to your account data.
+5. Review the consent screen, which lists the read-only scope being granted.
+6. After you approve, you are returned to Claude and the SnapTrade tools become available.
+
+## Set up the connector in ChatGPT
+
+1. In ChatGPT, go to **Settings → Apps & Connectors → Advanced settings** and turn on **Developer mode**.
+2. Go to **Settings → Connectors** and click **Create**.
+3. Enter a name (for example, `SnapTrade`) and the MCP server URL: `https://mcp.snaptrade.com/mcp`.
+4. Set the authentication method to **OAuth** and confirm you trust the application.
+5. Click **Create**, then complete the OAuth login flow with SnapTrade and approve **read** access.
+6. After you approve, the SnapTrade tools become available in your chats.
+
+> Note: Once the SnapTrade app is approved in the ChatGPT app directory, users can add it directly from the directory without enabling Developer mode.
+
+## Example prompts
+
+Once the connector is enabled, a user can ask their assistant questions like:
+
+- *"What brokerages am I connected to through SnapTrade?"*
+- *"Show me my current balances and positions across all my accounts."*
+- *"What were my last 10 orders across all my accounts?"*
+- *"I'd like to connect my Alpaca account."* — the assistant calls `request_connection_link` and hands the user a one-time URL to open in their browser.
+
+## Available tools
+
+The connector exposes 21 tools. All are read-only except `request_connection_link`, which generates a connection link for the user to open.
+
+**Connections**
+
+- `Connections_listBrokerageAuthorizations` — list the user's brokerage connections
+- `Connections_listBrokerageAuthorizationAccounts` — list the accounts under a connection
+
+**Account information**
+
+- `AccountInformation_getUserAccountDetails` — account details, including institution name and total value
+- `AccountInformation_getUserAccountBalance` — cash balances and buying power
+- `AccountInformation_getAllAccountPositions` — positions and holdings for an account
+- `AccountInformation_getAccountBalanceHistory` — historical account balances
+- `AccountInformation_getUserAccountOrders` — orders for an account
+- `AccountInformation_getUserAccountOrdersV2` — orders for an account (v2)
+- `AccountInformation_getUserAccountRecentOrders` — recent orders for an account
+- `AccountInformation_getUserAccountRecentOrdersV2` — recent orders for an account (v2)
+- `AccountInformation_getUserAccountOrderDetailV2` — details for a single order
+- `AccountInformation_getAccountActivities` — historical account activity such as deposits, dividends, and fees
+
+**Reference data**
+
+- `ReferenceData_listAllCurrencies` — supported currencies
+- `ReferenceData_listAllCurrenciesRates` — exchange rates for all supported currencies
+- `ReferenceData_getCurrencyExchangeRatePair` — exchange rate for a specific currency pair
+- `ReferenceData_getSecurityTypes` — supported security types
+- `ReferenceData_getStockExchanges` — supported stock exchanges
+- `ReferenceData_getSymbolsByTicker` — look up a symbol by ticker
+- `ReferenceData_getPartnerInfo` — brokerages and data access available to the connector
+
+**Connection helpers**
+
+- `list_supported_brokerages` — list the brokerages the user can connect
+- `request_connection_link` — generate a one-time URL the user opens to connect a new brokerage. The link is single-use and expires after 5 minutes. The assistant cannot complete the connection itself; only the user's browser session can.
+
+Every tool is annotated so AI clients and users can tell read operations from write operations. Read tools are marked `readOnlyHint: true` and `destructiveHint: false`; `request_connection_link` is marked `readOnlyHint: false` and `destructiveHint: true`. All tools are marked `openWorldHint: true`.
+
+## Manage and revoke access
+
+A user can revoke a connector's access at any time from the SnapTrade dashboard under **Settings → Connected apps**. Revoking access immediately invalidates the assistant's token.
+
+This is separate from disconnecting a brokerage — revoking connector access removes the AI assistant's access to SnapTrade, but leaves the user's brokerage connections intact.
+
+## Support
+
+- General support: `support@snaptrade.com`
+- Security vulnerability reports: `security@snaptrade.com`
+
+---
+
+## Related
+
+- [SnapTrade Connector Privacy Notice](https://docs.snaptrade.com/docs/connector-privacy)
+- [Getting Started with SnapTrade](https://docs.snaptrade.com/docs/getting-started)
+- [Brokerage Integrations](https://docs.snaptrade.com/docs/integrations)
+- [Terminology](https://docs.snaptrade.com/docs/terminology)

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -83,3 +83,9 @@ An explicit API-triggered sync request for a connection outside the periodic syn
 Aliases: forced sync, on-demand refresh
 
 Learn more: [Syncing and Data Freshness](https://docs.snaptrade.com/docs/syncing)
+
+## MCP Server
+SnapTrade's hosted Model Context Protocol server that lets AI assistants securely read a user's connected brokerage data.
+Aliases: AI connector, Claude connector, ChatGPT app
+
+Learn more: [SnapTrade MCP Server](https://docs.snaptrade.com/docs/mcp-server)

--- a/konfig.yaml
+++ b/konfig.yaml
@@ -65,6 +65,12 @@ portal:
               path: docs/ratelimiting.md
             - id: launch-guide
               path: docs/launching-your-application.md
+        - label: AI & MCP
+          links:
+            - id: mcp-server
+              path: docs/mcp-server.md
+            - id: connector-privacy
+              path: docs/connector-privacy.md
         - label: Core Concepts
           links:
             - id: terminology


### PR DESCRIPTION
Adds two docs pages for the new SnapTrade MCP server ahead of submitting it to the Anthropic Connectors Directory and the ChatGPT app store: `docs/mcp-server.md` (connector guide — overview, OAuth/security model, Claude + ChatGPT setup, example prompts, 21-tool inventory) and `docs/connector-privacy.md` (privacy notice covering data accessed, usage, retention, third-party sharing, and revocation). Both are wired into the `konfig.yaml` sidebar under a new "AI & MCP" section and cross-linked from `getting-started.md` and `terminology.md`. The privacy notice ships as a draft and needs legal/compliance sign-off — particularly the data-retention wording — before publishing. Verified: `konfig.yaml` parses with the correct sidebar order, all cross-links resolve to valid page ids, and the documented OAuth model and 21 tool names match the live server's discovery endpoints and inventory snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)