### PR TITLE
Docs: clarify API Key/Client ID/Consumer Key and update webhook example to use consumer key

### DIFF
--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,22 +1,17 @@
 # Terminology
 
-## API Key
-The app-level credential pair used to authenticate your integration with the SnapTrade API. An API key consists of a client ID (`clientId`) and a consumer key (`consumerKey`).
+## API Keys
+API Keys consist of a client ID (`clientId`) and a consumer key (`consumerKey`).
 Aliases: app credentials, integration credentials
 
 Learn more: [Getting Started: API Keys](https://docs.snaptrade.com/docs/getting-started#getting-started-api-keys), [FAQ: API Keys](https://docs.snaptrade.com/docs/faq#faq-api-keys)
 
 ## Client ID
-The public identifier for your SnapTrade API key. In direct API requests, it is sent as the `clientId` query parameter.
-Aliases: `clientId`
-
-Learn more: [Request Signatures](https://docs.snaptrade.com/docs/request-signatures)
+The public key for your SnapTrade API key. In direct API requests, it is sent as the `clientId` query parameter.
 
 ## Consumer Key
-The sensitive signing key for your SnapTrade API key. Use the consumer key when generating request signatures or validating webhook signatures.
-Aliases: `consumerKey`
-
-Learn more: [Request Signatures](https://docs.snaptrade.com/docs/request-signatures), [Webhooks](https://docs.snaptrade.com/docs/webhooks#verifying-webhook-authenticity)
+The secret key for your SnapTrade API key. Use the consumer key when generating request signatures or validating webhook signatures.
+Aliases: Client Secret
 
 ## SnapTrade User 
 A user record under your API key that represents one of your end users and authorizes access to that user's SnapTrade data.

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,10 +1,22 @@
 # Terminology
 
 ## API Key
-The app-level credential pair used to authenticate your integration and sign requests to the SnapTrade API.
-Aliases: client credentials, app credentials
+The app-level credential pair used to authenticate your integration with the SnapTrade API. An API key consists of a client ID (`clientId`) and a consumer key (`consumerKey`).
+Aliases: app credentials, integration credentials
 
 Learn more: [Getting Started: API Keys](https://docs.snaptrade.com/docs/getting-started#getting-started-api-keys), [FAQ: API Keys](https://docs.snaptrade.com/docs/faq#faq-api-keys)
+
+## Client ID
+The public identifier for your SnapTrade API key. In direct API requests, it is sent as the `clientId` query parameter.
+Aliases: `clientId`
+
+Learn more: [Request Signatures](https://docs.snaptrade.com/docs/request-signatures)
+
+## Consumer Key
+The sensitive signing key for your SnapTrade API key. Use the consumer key when generating request signatures or validating webhook signatures.
+Aliases: `consumerKey`
+
+Learn more: [Request Signatures](https://docs.snaptrade.com/docs/request-signatures), [Webhooks](https://docs.snaptrade.com/docs/webhooks#verifying-webhook-authenticity)
 
 ## SnapTrade User 
 A user record under your API key that represents one of your end users and authorizes access to that user's SnapTrade data.

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -11,7 +11,7 @@ The public key for your SnapTrade API key. In direct API requests, it is sent as
 
 ## Consumer Key
 The secret key for your SnapTrade API key. Use the consumer key when generating request signatures or validating webhook signatures.
-Aliases: Client Secret
+Aliases: client secret
 
 ## SnapTrade User 
 A user record under your API key that represents one of your end users and authorizes access to that user's SnapTrade data.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -8,9 +8,9 @@ To get started with webhooks, visit the webhook tab of the SnapTrade Dashboard t
 
 > Note: Webhook secrets are deprecated.
 
-You can verify the authenticity of any SnapTrade webhook by using the `Signature` header contained in the webhook headers, and comparing that to the expected signature generated using your **client secret**. Note that the client secret is different from the webhook secret that is being deprecated.
+You can verify the authenticity of any SnapTrade webhook by using the `Signature` header contained in the webhook headers, and comparing that to the expected signature generated using your **consumer key**. Note that the consumer key is different from the webhook secret that is being deprecated.
 
-The `Signature` header contains an HMAC SHA256 hash of the request body, using your client secret as the key.
+The `Signature` header contains an HMAC SHA256 hash of the request body, using your consumer key as the key.
 
 Here's an example implementation of a Flask webhook handler that verifies the authenticity of incoming webhooks:
 
@@ -25,7 +25,7 @@ from flask import Flask, request, jsonify
 
 app = Flask(__name__)
 
-SECRET = os.getenv("SNAPTRADE_CLIENT_SECRET")
+CONSUMER_KEY = os.getenv("SNAPTRADE_CONSUMER_KEY")
 
 @app.route('/', methods=['POST'])
 def webhook_listener():
@@ -37,7 +37,7 @@ def webhook_listener():
 
     # Verify the signature
     sig_content = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    sig_digest = hmac.new(SECRET.encode(), sig_content.encode(), sha256).digest()
+    sig_digest = hmac.new(CONSUMER_KEY.encode(), sig_content.encode(), sha256).digest()
     calculated_signature = b64encode(sig_digest).decode()
 
     if calculated_signature != signature:


### PR DESCRIPTION
### Motivation
- Clarify the distinction between the public and secret parts of an API key and standardize naming across the docs. 
- Surface the `clientId` (public identifier) and `consumerKey` (sensitive signing key) as first-class terms for implementers. 
- Ensure webhook verification guidance and code samples reference the correct signing secret name after deprecation of webhook secrets.

### Description
- Updated `docs/terminology.md` to expand the `API Key` entry and add separate `Client ID` and `Consumer Key` sections with their aliases and links. 
- Reworded webhook verification text in `docs/webhooks.md` to use `consumer key` instead of `client secret`. 
- Updated the Flask webhook example to use the environment variable `SNAPTRADE_CONSUMER_KEY` and the `CONSUMER_KEY` variable in the `hmac.new()` call. 
- Adjusted explanatory text to reference `consumerKey` for signature generation and webhook validation.

### Testing
- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a072d78e4648328b52429142dec8066)