### PR TITLE
Bump snaptrade-typescript-sdk to 10.0.0 (tsdown build)

### DIFF
--- a/.konfig/changesets/typescript-tsdown-build.md
+++ b/.konfig/changesets/typescript-tsdown-build.md
@@ -1,0 +1,5 @@
+---
+typescript: major
+---
+
+Switch TypeScript SDK build to tsdown with dual ESM/CJS output. Drops support for Node <18.


### PR DESCRIPTION
## Summary
Adds a major-bump changeset for the TypeScript SDK so the next bump workflow regenerates `sdks/typescript/` using the new tsdown templates that landed in [konfig-snaptrade#77](https://github.com/passiv/konfig-snaptrade/pull/77) and publishes `snaptrade-typescript-sdk@10.0.0`. Major because `engines.node` moves from `>=10` to `>=18` (build system switches from tsc+webpack to tsdown with dual ESM/CJS output).

## Expected flow
1. Merge this PR
2. `release.yaml` → `bump.yaml` sees the changeset, runs `konfig version` (bumps `konfig.yaml#generators.typescript.version` to `10.0.0`, deletes the changeset) then `konfig generate` (uses the new tsdown templates)
3. `bump.yaml` opens a "Version Bump SDKs" PR with the regenerated TS SDK — `tsdown.config.ts` + `scripts/sync-version.mjs` appear, `webpack.config.js` is gone, `package.json`/`tsconfig.json` swap to the new build setup
4. CI runs `konfig test --filter typescript` (pnpm i + pnpm test + pnpm build with tsdown) against the regenerated SDK
5. Bump PR auto-merges, `publish.yaml` ships `10.0.0` to npm

## Test plan
- [ ] Bump PR is opened with the expected diff (tsdown.config.ts, scripts/sync-version.mjs, package.json/tsconfig.json rewritten, webpack.config.js deleted)
- [ ] `konfig test --filter typescript` passes on the bump PR
- [ ] Published `snaptrade-typescript-sdk@10.0.0` resolves correctly for both CJS and ESM consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)