### PR TITLE
chore(konfig): hide experimental endpoints using hideTags

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -177,6 +177,7 @@ portal:
     - name: PartnerTimestamp
 filterTags:
   - Webhooks
+hideTags:
   - Experimental endpoints
 filterModels:
   - SnapTradePartnerAPICredential


### PR DESCRIPTION
### Motivation
- Use the new Konfig `hideTags` setting to hide the "Experimental endpoints" tag from docs but keep in SDKs (instead of relying on `filterTags` semantics).

### Description
- Updated `konfig.yaml` to add a top-level `hideTags` entry containing `Experimental endpoints` and left `filterTags` scoped to `Webhooks`, so experimental endpoints are hidden by the Konfig generator.

### Testing
- Verified the change is present in `konfig.yaml` (inspected the file region showing `hideTags: - Experimental endpoints`) and ran repository searches to confirm the tag is no longer listed under `filterTags`; no SDK generation was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1038d035648328a35d8bd13ba97110)