### PR TITLE
ci: configure release workflow for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,13 +7,15 @@ on:
 
 jobs:
   release:
+    permissions:
+      id-token: write
+      contents: read
     uses: passiv/konfig-workflows/.github/workflows/release.yaml@main
     secrets:
       TEST_ENV: ${{ secrets.TEST_ENV }}
       KONFIG_API_KEY: ${{ secrets.KONFIG_API_KEY }}
       SUBMODULE_DEPLOY_KEY_PHP: ${{ secrets.SUBMODULE_DEPLOY_KEY_PHP }}
       SUBMODULE_DEPLOY_KEY_PHP7: ${{ secrets.SUBMODULE_DEPLOY_KEY_PHP7 }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       PYPI_TOKEN_1: ${{ secrets.PYPI_TOKEN_1 }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
### Motivation
- Move npm publishing from a long-lived `NPM_TOKEN` secret to GitHub Actions OIDC for improved security and short-lived credentials.
- Ensure the reusable release workflow has the permissions required for OIDC-based publishing and minimal repository access.

### Description
- Added `permissions` to the `release` job with `id-token: write` and `contents: read` in ` .github/workflows/release.yaml` to enable OIDC flows.
- Removed the explicit `NPM_TOKEN` secret mapping from the reusable release workflow invocation so npm publishing can rely on OIDC instead of a long-lived token.

### Testing
- Ran `rg -n "npm|publish|OIDC|id-token|provenance|NPM_TOKEN|npm publish" .github/workflows` to confirm the `NPM_TOKEN` mapping was removed and the OIDC-related keywords are present, which succeeded.
- Inspected the diff for ` .github/workflows/release.yaml` to confirm the `permissions` block was added and the `NPM_TOKEN` entry was removed, which matched expectations.
- Applied the patch to the repo and verified the updated workflow file exists in the repository, with no automated failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14a37e92f0832883adf8e8079a45af)