### PR TITLE
chore(typescript-sdk): shrink published package by ~49%

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -19,6 +19,7 @@
     "snaptrade-typescript-sdk"
   ],
   "license": "Unlicense",
+  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/sdks/typescript/tsdown.config.ts
+++ b/sdks/typescript/tsdown.config.ts
@@ -9,7 +9,7 @@ import { resolve } from "node:path";
 
 const shared = {
   entry: ["./index.ts"],
-  sourcemap: true,
+  sourcemap: false,
   target: "node18",
   outDir: "dist",
   treeshake: true,


### PR DESCRIPTION
## Summary

Two small, non-breaking edits cut the published `snaptrade-typescript-sdk` tarball roughly in half:

- **Stop shipping sourcemaps** — flip `sourcemap: true` → `sourcemap: false` in [sdks/typescript/tsdown.config.ts](https://github.com/passiv/snaptrade-sdks/blob/claude/affectionate-bartik-d4729a/sdks/typescript/tsdown.config.ts). The two `.map` files were ~1.2 MB of the unpacked tarball.
- **Declare side-effect-free** — add `"sideEffects": false` to [sdks/typescript/package.json](https://github.com/passiv/snaptrade-sdks/blob/claude/affectionate-bartik-d4729a/sdks/typescript/package.json). Doesn't change the tarball but lets webpack/Rollup/esbuild tree-shake unused API classes and model interfaces through the barrel exports, shrinking what consumers ship to their end users.

## Size impact

| | Before | After | Delta |
|---|---|---|---|
| Tarball (gzipped) | 234.7 kB | **128.5 kB** | −45% |
| Unpacked | 2.46 MB | **1.25 MB** | −49% |
| Files | 10 | 8 | -2 (`.map` files) |

## Trade-offs and what's not changed

- **Sourcemaps**: stack traces from production code will reference bundled line numbers instead of original `.ts` lines. Consumers debugging into the SDK can opt to build from source if needed.
- **`sideEffects: false` is safe**: the SDK is pure class/type definitions plus three hook modules that export functions — no module-level code that runs for its side effect.
- **README.md (112 kB)** is still in the tarball — npm always includes the root README regardless of `files`. Konfig regenerates it, so trimming would need a publish-time swap; deferred.
- **CJS + ESM dual build** kept for compatibility.
- Both edited files are hand-written and survive Konfig regeneration.

## Test plan

- [x] `npm run build` succeeds; `dist/` drops from 2.3 MB to 1.1 MB; no `.map` files in output
- [x] `npm run typecheck` passes
- [x] `npm pack --dry-run` confirms tarball drops to 128.5 kB and the file list excludes `.map` files
- [ ] Integration tests in `index.test.ts` / `mock.test.ts` require live `SNAPTRADE_*` credentials and weren't run in this session — neither change touches runtime code, so no regression risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)