### PR TITLE
chore: update the docs portal revalidation workflow

### DIFF
--- a/.github/workflows/konfig-revalidate-portal.yaml
+++ b/.github/workflows/konfig-revalidate-portal.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install Konfig CLI
         uses: passiv/konfig-workflows/.github/actions/install-cli@main
 
       - name: Revalidate Portal
-        run: konfig revalidate-portal -o passiv -r snaptrade-sdks
+        run: konfig revalidate-portal


### PR DESCRIPTION
- remove the legacy multi-host owner/repo params from `konfig revalidate` command
- upgrade checkout action to the node 20+