### PR TITLE
Unhide the GET /accounts endpoint in SDKs

### DIFF
--- a/konfig.yaml
+++ b/konfig.yaml
@@ -176,8 +176,6 @@ portal:
       delete: true
     /accounts/{accountId}/holdings:
       get: true
-    /accounts:
-      get: true
   hideTags:
     - Experimental endpoints
   hideSecurity:


### PR DESCRIPTION
Removes the `GET /accounts` operation from `hideOperations` in `konfig.yaml` so it is no longer hidden from the generated SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)