### PR TITLE
Document per-account rate limit on quotes endpoint

### DIFF
--- a/docs/ratelimiting.md
+++ b/docs/ratelimiting.md
@@ -53,6 +53,7 @@ Account-level rate limiting applies to the following endpoints:
 - :api[AccountInformation_getUserAccountRecentOrders]
 - :api[AccountInformation_getAccountActivities]
 - :api[AccountInformation_getUserAccountOrderDetail]
+- :api[Trading_getUserAccountQuotes]
 
 > **Note:** While the per-account rate limit allows up to 10 requests per minute, these endpoints should not be polled at this frequency. See [API Polling Patterns](https://docs.snaptrade.com/docs/launching-your-application#3-api-polling-patterns) for recommended usage patterns.
 


### PR DESCRIPTION
## Summary

Updates the rate limiting docs to reflect that the quotes endpoint (`MarketQuoteView` / `Trading_getUserAccountQuotes`) is also throttled on a **per-account** basis.

The Account-Level Rate Limiting section lists the endpoints subject to the per-account (10 req/min/account) limit, but was missing the quotes endpoint. This adds it to that list.

## Changes

- Add `:api[Trading_getUserAccountQuotes]` to the "Affected Endpoints" list in `docs/ratelimiting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)