### PR TITLE
[codex] Document Personal vs Commercial plans

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,24 +1,26 @@
 # How We Bill at SnapTrade
 
-This document explains every component of SnapTrade's billing process so you know exactly what you're paying for, when you'll be invoiced, and how payments work.
+This document explains every component of SnapTrade's Commercial billing process so you know exactly what you're paying for, when you'll be invoiced, and how payments work.
+
+Personal users are currently completely free. Commercial customers may be billed based on connected users, API usage, platform fees, or monthly minimums depending on their agreement. If you are deciding which customer model applies to your integration, start with [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial).
 
 ---
 
 ## Billing Cycle
 
-SnapTrade bills on a **monthly** cycle. Each invoice covers usage from the 1st through the last day of the previous calendar month. Invoices are generated on the **1st of each month**.
+SnapTrade bills Commercial customers on a **monthly** cycle. Each invoice covers usage from the 1st through the last day of the previous calendar month. Invoices are generated on the **1st of each month**.
 
 ---
 
 ## What We Charge For
 
-Your monthly invoice can include up to four types of charges:
+A Commercial monthly invoice can include up to four types of charges:
 
 ### 1. Connected Users (Tiered Pricing)
 
-The primary component of your bill is based on the number of **unique users** who had an active or inactive brokerage connection during the billing period. A "user" is identified by the `user_id` assigned when creating users in your application. For more details on user creation, see the [SnapTrade user creation documentation](https://docs.snaptrade.com/docs/getting-started#getting-started-users).
+The primary component of a Commercial bill is based on the number of **unique users** who had an active or inactive brokerage connection during the billing period. A "user" is identified by the `user_id` assigned when creating users in your application. For more details on user creation, see the [SnapTrade user creation documentation](https://docs.snaptrade.com/docs/getting-started#getting-started-users).
 
-By default, all customers start with a single flat rate of **$2.00 per connected user per month**. As your business scales, you can negotiate volume-based tiered pricing where additional users above certain thresholds are charged at progressively lower rates. Contact support if you're interested in negotiating bulk tiered pricing.
+By default, Commercial customers start with a single flat rate of **$2.00 per connected user per month**. As your business scales, you can negotiate volume-based tiered pricing where additional users above certain thresholds are charged at progressively lower rates. Contact support if you're interested in negotiating bulk tiered pricing.
 
 **Example of tiered pricing:**
 
@@ -28,7 +30,7 @@ By default, all customers start with a single flat rate of **$2.00 per connected
 | 2    | 101 - 500 | $1.75        |
 | 3    | 501+      | $1.50        |
 
-With 250 connected users in this example, your bill would be:
+With 250 connected users in this example, the Commercial bill would be:
 - 100 users x $2.00 = $200.00
 - 150 users x $1.75 = $262.50
 - **Total: $462.50**
@@ -37,13 +39,13 @@ With 250 connected users in this example, your bill would be:
 
 ### 2. Manual Refreshes
 
-If your agreement with SnapTrade contains pricing for manual refreshes, they will be charged according to the following details.
+If your Commercial agreement with SnapTrade contains pricing for manual refreshes, they will be charged according to the following details.
 
-When your application triggers a manual data refresh (sync) for a user's account, each refresh is recorded as a billable event. The default rate is set per customer based on their agreement with SnapTrade. This feature is disabled for Pay as you Go and free plans.
+When your application triggers a manual data refresh (sync) for a user's account, each refresh is recorded as a billable event. The default rate is set per Commercial customer based on their agreement with SnapTrade. This feature is disabled for Pay as you Go and free plans.
 
 ### 3. Recent Orders API Calls
 
-If your plan includes provisions for the `/recentOrders` endpoint, each API call to this endpoint is billed at a per-call rate defined in your agreement.
+If your Commercial plan includes provisions for the `/recentOrders` endpoint, each API call to this endpoint is billed at a per-call rate defined in your agreement.
 
 Pay as You Go customers have this feature included at no extra charge although this feature may be subject to rate limits at higher volumes.
 
@@ -57,7 +59,7 @@ Custom plans may include a **monthly minimum fee**. If your usage-based charges 
 
 ## Invoice Total
 
-Your invoice total is calculated as:
+A Commercial invoice total is calculated as:
 
 ```
   Connected users charge (accounting for tiered pricing if applicable)
@@ -77,7 +79,7 @@ Your invoice total is calculated as:
 
 ## What Happens If an Invoice Goes Unpaid
 
-SnapTrade takes the following steps for overdue invoices:
+SnapTrade takes the following steps for overdue Commercial invoices:
 
 1. **Reminder emails** are sent on the 1st of each month to customers with any invoices past their due date. The email includes the total outstanding amount, your production API key slug, and the date your keys will be disabled if payment is not received.
 
@@ -94,10 +96,10 @@ SnapTrade takes the following steps for overdue invoices:
 
 ## Viewing Your Billing Details
 
-Use the [SnapTrade Dashboard](https://dashboard.snaptrade.com/settings/billing) to view invoices, download PDFs, and manage payment methods.
+Commercial customers can use the [SnapTrade Dashboard](https://dashboard.snaptrade.com/settings/billing) to view invoices, download PDFs, and manage payment methods.
 
 ---
 
 ## Questions?
 
-If you have questions about your bill or need to discuss your pricing, reach out to your SnapTrade account contact or email the billing address provided in your invoice communications.
+If you have questions about your Commercial bill or need to discuss your pricing, reach out to your SnapTrade account contact or email the billing address provided in your invoice communications.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,8 @@ Welcome to SnapTrade! This is intended to be one of the first documents you read
 
 If you want a quick definitions reference while reading, see [Terminology](https://docs.snaptrade.com/docs/terminology).
 
+If you are unsure whether to build as an individual user or as an app with many end users, see [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial).
+
 Please see the FAQ of each section, as any questions you might have should be answered there.
 
 If after reading this document you still have questions or need help, please do not hesitate to contact us through our [Discord](https://discord.gg/rkYWBxb8Qu).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -14,6 +14,8 @@ The SnapTrade MCP server is for **SnapTrade Personal** users — individuals who
 
 To use the connector, you'll need a free SnapTrade Personal account. If you don't have one yet, sign up at the [SnapTrade Dashboard](https://dashboard.snaptrade.com/signup) and link at least one brokerage account before adding the connector to your AI assistant.
 
+For a broader comparison of Personal and Commercial customer experiences, see [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial).
+
 ## What you can do with it
 
 With the SnapTrade connector enabled, an AI assistant can:

--- a/docs/personal-vs-commercial.md
+++ b/docs/personal-vs-commercial.md
@@ -1,0 +1,171 @@
+# SnapTrade Personal vs Commercial
+
+SnapTrade supports two primary customer experiences: **Personal** and **Commercial**. Both can use SnapTrade to connect brokerage accounts, retrieve account data, and, where enabled, place trades. The important difference is who owns the SnapTrade account and how users are represented.
+
+Use this guide to choose the right integration model before building authentication, user registration, connection management, billing, and support flows.
+
+:::info
+Personal and Commercial are customer experiences, not billing plan names. Billing plans such as Free, Pay-as-you-go, and Enterprise control limits, pricing, and feature availability. A customer's Personal or Commercial experience controls how SnapTrade users, credentials, OAuth, and Connection Portal flows behave.
+:::
+
+## Quick Comparison
+
+| Area | Personal | Commercial |
+| --- | --- | --- |
+| Intended user | An individual using SnapTrade for their own brokerage accounts | A company building an app for its own end users |
+| SnapTrade account owner | The individual investor | The developer, company, or partner |
+| End-user model | The signed-in Personal user is the SnapTrade user | Your app creates one SnapTrade `userId` and `userSecret` per end user |
+| Authentication options | Personal OAuth, or Personal client ID and consumer key | Commercial client ID and consumer key |
+| API authorization | OAuth Bearer token for Personal OAuth, or signed requests with a Personal consumer key | Signed requests using the Commercial consumer key |
+| User registration | Do not call :api[Authentication_registerSnapTradeUser] for Personal OAuth | Call :api[Authentication_registerSnapTradeUser] before creating connections |
+| Connection Portal | Opens for the Personal user's own brokerage connections | Opens for a specific SnapTrade user managed by your app |
+| MCP server | Supported; the MCP server is designed for SnapTrade Personal users | Not used with Commercial developer API keys |
+| Key lifecycle | Personal customers can create one Personal client ID and consumer key in the dashboard | Commercial customers start with a test key and can create production keys after KYC approval |
+| Billing | Free | Connected users and usage under the Commercial customer agreement |
+
+## Choose Personal When
+
+Choose the Personal experience when the person using SnapTrade is connecting and managing their own brokerage accounts.
+
+Common Personal use cases include:
+
+- An individual using the SnapTrade Dashboard directly.
+- A CLI, desktop app, or AI assistant connector that lets the user sign in with their own SnapTrade account.
+- Portfolio analysis and trading for the user's own accounts.
+- Connection management for the user's own brokerages.
+
+Personal OAuth is the preferred pattern when your app should not handle SnapTrade API credentials directly. The user signs in with SnapTrade, your app receives OAuth tokens, and API calls are scoped to that Personal user.
+
+For Personal OAuth:
+
+- Use authorization code with PKCE.
+- Store OAuth tokens securely.
+- Do not create a SnapTrade user with :api[Authentication_registerSnapTradeUser].
+- Do not store or send a `userSecret`.
+- Omit `userId` and `userSecret` when opening the Connection Portal; the Bearer token identifies the Personal user.
+- Treat the current `read` scope as account data and connection management, not trade placement or order modification.
+
+Personal client ID and consumer key authentication is available for Personal users who need signed-request workflows, including trading with their own accounts where enabled. In that case, the user still represents themselves. Unlike a Commercial integration, your app should not create a separate SnapTrade user for them.
+
+## Choose Commercial When
+
+Choose the Commercial experience when you are building an application for your own end users and need SnapTrade as infrastructure behind your product.
+
+Common Commercial use cases include:
+
+- A fintech app that lets many app users connect their brokerages.
+- A portfolio management, tax, financial planning, trading, or analytics product.
+- A backend service that needs to create, track, and support many SnapTrade users.
+- Production integrations that need webhooks, billing, compliance review, and higher limits.
+
+Commercial integrations use a SnapTrade client ID and consumer key. Your backend signs requests with the consumer key and keeps that key secret.
+
+For each end user in your application:
+
+1. Create a stable SnapTrade `userId` with :api[Authentication_registerSnapTradeUser].
+2. Store the returned `userSecret` securely.
+3. Generate a Connection Portal link with :api[Authentication_loginSnapTradeUser].
+4. Send your end user through the Connection Portal.
+5. Use the `userId`, `userSecret`, and account IDs to retrieve data or perform enabled trading workflows.
+
+Commercial `userId` values should be immutable identifiers from your system. Avoid email addresses because users can change emails and because user IDs may appear in logs, support workflows, or billing reconciliation.
+
+## Credentials And Keys
+
+Both experiences can involve a SnapTrade client ID and consumer key, but they are used differently.
+
+**Personal client ID and consumer key**
+
+- Belong to an individual Personal customer.
+- Represent that individual's SnapTrade access.
+- Do not imply that your app should create subordinate SnapTrade users.
+- Are useful for local tools or advanced Personal workflows where signed-request authentication is available.
+
+**Commercial client ID and consumer key**
+
+- Belong to a company or developer customer.
+- Represent an integration that manages many SnapTrade users.
+- Must be stored only on a backend or other secure server-side environment.
+- Are used to generate request signatures and validate webhook signatures.
+
+In the SnapTrade Dashboard, Commercial customers typically create a test key first. Production key creation requires KYC approval and a payment method. Personal customers are limited to one free Personal client ID and consumer key, which they can use for their own production use cases.
+
+## Users And Connections
+
+The biggest implementation difference is whether your app creates SnapTrade users.
+
+### Personal
+
+With Personal OAuth, the OAuth token identifies the SnapTrade user. Your app can call normal SnapTrade APIs, but user identity is inferred from the token. Do not call user-registration endpoints or store a `userSecret`.
+
+When opening the Connection Portal for a Personal OAuth user, generate the portal link without `userId` or `userSecret`. SnapTrade resolves the Personal user's context from the Bearer token.
+
+### Commercial
+
+With Commercial client ID and consumer key authentication, your app owns user mapping. Each end user of your app should have a corresponding SnapTrade user.
+
+A typical mapping is:
+
+```
+Your app user  ->  SnapTrade userId + userSecret  ->  connections  ->  accounts
+```
+
+Create one SnapTrade user per end user, then create one or more brokerage connections under that user. When a brokerage login contains multiple brokerage accounts, those accounts appear under the same connection.
+
+## Trading And Write Access
+
+Feature availability depends on the customer, key, brokerage, account, and plan.
+
+Personal users can trade with their own accounts using SnapTrade client ID and consumer key authentication where trading is enabled for the account and brokerage.
+
+For Personal OAuth, the current `read` scope supports account data and connection-management workflows. Trading and other write operations require SnapTrade client ID and consumer key authentication where enabled.
+
+For Commercial integrations, trading requires:
+
+- A Commercial key with trading features enabled.
+- A brokerage and account that support trading.
+- A connection created with the appropriate connection type.
+- Your application's own user confirmation and compliance flow before submitting orders.
+
+## MCP And AI Connectors
+
+The SnapTrade MCP server is a Personal experience. It lets AI assistants read a Personal user's connected brokerage data after the user signs in with SnapTrade OAuth and approves read access.
+
+Commercial developer API keys are not used with the hosted MCP server. If you are building a Commercial product that includes AI features, your backend should use your Commercial integration model and expose only the user-facing AI behavior you intend to support.
+
+## Billing And Limits
+
+Personal versus Commercial determines the user model. Personal users are currently completely free. Commercial billing plans determine pricing, limits, and enabled features for Commercial customers.
+
+Commercial billing is usually based on connected users and usage under the customer's agreement. A connected user is an end user who has at least one completed brokerage connection or relevant sync activity during the billing period.
+
+Plan-level settings can affect:
+
+- Number of allowed connections.
+- Whether data is real-time or daily.
+- Whether manual refreshes are enabled or billable.
+- Access to recent orders, trading, and other paid features.
+- Whether production keys can be created.
+
+For Commercial integrations, design your onboarding, usage tracking, and support workflows around the connected-user model described in [Billing](https://docs.snaptrade.com/docs/billing). Personal users do not need to design around Commercial connected-user billing.
+
+## Implementation Checklist
+
+Before building, decide:
+
+- Is the person connecting accounts the SnapTrade customer, or is your company the SnapTrade customer?
+- Will users sign in with SnapTrade OAuth, or will your backend sign API requests with a consumer key?
+- Should your app call :api[Authentication_registerSnapTradeUser]?
+- Where will credentials, OAuth tokens, and user secrets be stored?
+- Who owns support for reconnecting brokerages and removing connections?
+- If you are building a Commercial integration, which billing plan controls limits, data freshness, and feature access?
+
+If the user owns the SnapTrade account, use the Personal model. If your app owns the integration and manages many end users, use the Commercial model.
+
+## Related
+
+- [Getting Started with SnapTrade](https://docs.snaptrade.com/docs/getting-started)
+- [Terminology](https://docs.snaptrade.com/docs/terminology)
+- [SnapTrade MCP Server](https://docs.snaptrade.com/docs/mcp-server)
+- [Billing](https://docs.snaptrade.com/docs/billing)
+- [Request Signatures](https://docs.snaptrade.com/docs/request-signatures)

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -6,6 +6,16 @@ Aliases: app credentials, integration credentials
 
 Learn more: [Getting Started: API Keys](https://docs.snaptrade.com/docs/getting-started#getting-started-api-keys), [FAQ: API Keys](https://docs.snaptrade.com/docs/faq#faq-api-keys)
 
+## Personal Customer
+A free SnapTrade customer experience for individuals who connect and manage their own brokerage accounts. Personal users can use SnapTrade OAuth or a Personal client ID and consumer key.
+
+Learn more: [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial)
+
+## Commercial Customer
+A SnapTrade customer experience for companies and developers building apps for their own end users. Commercial integrations use a client ID and consumer key, create SnapTrade users for app users, and manage connections under those users.
+
+Learn more: [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial)
+
 ## Client ID
 The public key for your SnapTrade API key. In direct API requests, it is sent as the `clientId` query parameter.
 

--- a/konfig.yaml
+++ b/konfig.yaml
@@ -51,6 +51,8 @@ portal:
           links:
             - id: getting-started
               path: docs/getting-started.md
+            - id: personal-vs-commercial
+              path: docs/personal-vs-commercial.md
             - id: implement-connection-portal
               path: docs/implement-connection-portal.md
             - id: trading-with-snaptrade


### PR DESCRIPTION
## Summary

- Add a new guide explaining SnapTrade Personal vs Commercial customer experiences.
- Add the guide to the docs sidebar and cross-link it from Getting Started, Terminology, MCP, and Billing docs.
- Clarify that Personal users are currently free, can use Personal client ID and consumer key authentication for their own production use cases, and can trade with their own accounts where enabled.
- Scope read-only limitations to Personal OAuth and MCP, and make Commercial billing/KYC language explicit.

## Validation

- `git diff --check`
- `git diff --cached --check` before commit