### PR TITLE
Restrict release workflow to Konfig-related path changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - master
+    paths:
+      - api.yaml
+      - konfig.yaml
+      - .konfig/**
+      - sdks/**
+      - snippets/**
+      - templates/**
+      - flows/**
 
 
 jobs:


### PR DESCRIPTION
### Motivation
- Reduce unnecessary release runs by restricting the `release` workflow to changes affecting `api.yaml`, `konfig.yaml`, `.konfig/**`, `sdks/**`, `snippets/**`, `templates/**`, and `flows/**` on `master`.

### Description
- Add a `paths` filter under the `push` trigger in `.github/workflows/release.yaml` listing `api.yaml`, `konfig.yaml`, `.konfig/**`, `sdks/**`, `snippets/**`, `templates/**`, and `flows/**` so the release job only runs for relevant changes.

### Testing
- No automated tests were run for this CI configuration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21a3f38e10832896d611e13771cced)