### PR TITLE
Limit konfig-lint workflow triggers to API and konfig file changes

### DIFF
--- a/.github/workflows/konfig-lint.yaml
+++ b/.github/workflows/konfig-lint.yaml
@@ -1,9 +1,15 @@
 name: konfig-lint-openapi-spec
-on: # rebuild any PRs and main branch changes
+on: # rebuild PRs and main branch changes when spec inputs change
   pull_request:
+    paths:
+      - api.yaml
+      - konfig.yaml
   push:
     branches:
       - master
+    paths:
+      - api.yaml
+      - konfig.yaml
 jobs:
   konfig-lint-openapi-spec: # make sure spec passes konfig lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Restrict the `konfig-lint-openapi-spec` workflow to rebuild only when `api.yaml` or `konfig.yaml` change to avoid unnecessary runs.

### Description
- Add `paths` filters under `pull_request` and `push` for branch `master` in `.github/workflows/konfig-lint.yaml` so the workflow triggers only on changes to `api.yaml` and `konfig.yaml`.

### Testing
- No automated tests were executed as part of this PR; the workflow will run `konfig lint api.yaml` in CI when the specified files change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21a5eca754832895aad9621e9506a3)