### PR TITLE
docs: clarify Manual Sync billing for Pay-as-you-go Daily

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -41,7 +41,7 @@ With 250 connected users in this example, the Commercial bill would be:
 
 If your Commercial agreement with SnapTrade contains pricing for manual refreshes, they will be charged according to the following details.
 
-When your application triggers a manual data refresh (sync) for a user's account, each refresh is recorded as a billable event. The default rate is set per Commercial customer based on their agreement with SnapTrade. This feature is disabled for Pay as you Go and free plans.
+When your application triggers a manual data refresh (sync) for a user's account, each refresh is recorded as a billable event. The default rate is set per Commercial customer based on their agreement with SnapTrade. Manual Sync is available for Pay-as-you-go Daily plans at **$0.05 per account**. This feature remains disabled for free plans.
 
 ### 3. Recent Orders API Calls
 


### PR DESCRIPTION
### Motivation
- Update documentation to reflect the new pricing change so customers know Manual Sync is available on Pay-as-you-go Daily plans at the announced rate.

### Description
- Replace the previous statement that Manual Sync was disabled for Pay-as-you-go with a clarifying line in `docs/billing.md` stating: "Manual Sync is available for Pay-as-you-go Daily plans at **$0.05 per account**" and that it remains disabled for free plans.
- The only file changed in this PR is `docs/billing.md`; unrelated modifications to `sdks/typescript/pnpm-lock.yaml` were left untouched.

### Testing
- Ran `git diff --check -- docs/billing.md` to validate there are no whitespace or formatting issues and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2c2ad9ae3c8328a16f4b11b721a3a5)