### PR TITLE
Make manual SDK regeneration optionally create PR and support configurable branches

### DIFF
--- a/.github/workflows/regenerate-sdks-manual.yaml
+++ b/.github/workflows/regenerate-sdks-manual.yaml
@@ -88,7 +88,6 @@ jobs:
       changeset_message: ${{ inputs.changeset_message }}
       base_branch: ${{ inputs.base_branch }}
       head_branch: ${{ inputs.create_pull_request && (inputs.head_branch || format('sdk-regeneration/manual-{0}', github.run_id)) || inputs.base_branch }}
-      create_pull_request: false
     secrets:
       TEST_ENV: ${{ secrets.TEST_ENV }}
       KONFIG_API_KEY: ${{ secrets.KONFIG_API_KEY }}

--- a/.github/workflows/regenerate-sdks-manual.yaml
+++ b/.github/workflows/regenerate-sdks-manual.yaml
@@ -17,9 +17,67 @@ on:
         description: Description to use for the generated SDK changeset
         required: true
         type: string
+      create_pull_request:
+        description: Create a pull request for the generated SDK changes
+        required: true
+        default: true
+        type: boolean
+      base_branch:
+        description: Branch to create the SDK regeneration branch from
+        required: true
+        default: master
+        type: string
+      head_branch:
+        description: Branch to run SDK regeneration on. Defaults to sdk-regeneration/manual-<run id> when creating a PR.
+        required: false
+        default: ''
+        type: string
 
 jobs:
+  create-pull-request:
+    name: Create pull request
+    if: inputs.create_pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      HEAD_BRANCH: ${{ inputs.head_branch || format('sdk-regeneration/manual-{0}', github.run_id) }}
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+
+      - name: Create regeneration branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$HEAD_BRANCH"
+          git commit --allow-empty -m "chore: prepare manual SDK regeneration"
+          git push --set-upstream origin "$HEAD_BRANCH"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > pr-body.md <<'PR_BODY'
+          Manually triggered SDK regeneration from ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+
+          Changeset type: ${{ inputs.changeset_type }}
+          Changeset message: ${{ inputs.changeset_message }}
+          PR_BODY
+
+          gh pr create \
+            --base "${{ inputs.base_branch }}" \
+            --head "$HEAD_BRANCH" \
+            --title "Regenerate SDKs" \
+            --body-file pr-body.md
+
   regenerate-sdks-manual:
+    name: Regenerate SDKs
+    needs: create-pull-request
+    if: always() && (needs.create-pull-request.result == 'success' || needs.create-pull-request.result == 'skipped')
     permissions:
       contents: write
       pull-requests: write
@@ -28,15 +86,9 @@ jobs:
       konfig_yaml_dir: ./
       changeset_type: ${{ inputs.changeset_type }}
       changeset_message: ${{ inputs.changeset_message }}
-      base_branch: master
-      head_branch: sdk-regeneration/manual-${{ github.run_id }}
-      create_pull_request: true
-      pull_request_title: Regenerate SDKs
-      pull_request_body: |
-        Manually triggered SDK regeneration from ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
-
-        Changeset type: ${{ inputs.changeset_type }}
-        Changeset message: ${{ inputs.changeset_message }}
+      base_branch: ${{ inputs.base_branch }}
+      head_branch: ${{ inputs.create_pull_request && (inputs.head_branch || format('sdk-regeneration/manual-{0}', github.run_id)) || inputs.base_branch }}
+      create_pull_request: false
     secrets:
       TEST_ENV: ${{ secrets.TEST_ENV }}
       KONFIG_API_KEY: ${{ secrets.KONFIG_API_KEY }}

--- a/.github/workflows/regenerate-sdks-on-oas-change.yaml
+++ b/.github/workflows/regenerate-sdks-on-oas-change.yaml
@@ -17,6 +17,8 @@ jobs:
     if: github.event.pull_request.draft == false
     with:
       konfig_yaml_dir: ./
+      base_branch: ${{ github.base_ref }}
+      head_branch: ${{ github.head_ref }}
     secrets:
       TEST_ENV: ${{ secrets.TEST_ENV }}
       KONFIG_API_KEY: ${{ secrets.KONFIG_API_KEY }}


### PR DESCRIPTION
### Motivation

- Allow users to choose whether the manual SDK regeneration flow creates a pull request, and to run regeneration from configurable base/head branches.
- Ensure repositories that already prepare a branch/PR can call the reusable regeneration workflow without duplicating PR creation.

### Description

- Added workflow-dispatch inputs `create_pull_request`, `base_branch`, and optional `head_branch` to `.github/workflows/regenerate-sdks-manual.yaml` to control PR creation and branch selection.
- Added a `create-pull-request` job that, when `create_pull_request` is true, checks out `base_branch`, prepares a regeneration branch (defaulting to `sdk-regeneration/manual-<run id>`), pushes it, and opens the PR using `gh` with a generated body file.
- Updated the `regenerate-sdks-manual` job to depend on the PR job, to run on the selected branch, and to invoke the reusable `passiv/konfig-workflows/.github/workflows/regenerate-sdks.yaml@main` with `create_pull_request: false` so the reusable workflow only performs generation/commit/push steps.
- Added minimal git author configuration and an empty commit in the PR creation job to ensure the new branch is present on the remote for the regeneration run.

### Testing

- Validated the workflow YAML syntax with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/regenerate-sdks-manual.yaml"); puts "yaml ok"'`, which printed `yaml ok` (note: `mise` emitted warnings while resolving `dotnet@7` but did not affect YAML parsing).
- Ran `git diff --check -- .github/workflows/regenerate-sdks-manual.yaml`, which reported no conflicts or whitespace errors.
- Confirmed the updated workflow file contents match the intended inputs and job wiring via a local diff inspection command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4287772ce883289ac216e942d01f9a)