### PR TITLE
Allow manual SDK regeneration to read GitHub Packages

### DIFF
--- a/.github/workflows/regenerate-sdks-manual.yaml
+++ b/.github/workflows/regenerate-sdks-manual.yaml
@@ -73,10 +73,6 @@ jobs:
     name: Regenerate SDKs
     needs: create-pull-request
     if: always() && (needs.create-pull-request.result == 'success' || needs.create-pull-request.result == 'skipped')
-    permissions:
-      contents: write
-      packages: read
-      pull-requests: write
     uses: passiv/konfig-workflows/.github/workflows/regenerate-sdks.yaml@main
     with:
       konfig_yaml_dir: ./

--- a/.github/workflows/regenerate-sdks-manual.yaml
+++ b/.github/workflows/regenerate-sdks-manual.yaml
@@ -75,6 +75,7 @@ jobs:
     if: always() && (needs.create-pull-request.result == 'success' || needs.create-pull-request.result == 'skipped')
     permissions:
       contents: write
+      packages: read
       pull-requests: write
     uses: passiv/konfig-workflows/.github/workflows/regenerate-sdks.yaml@main
     with:


### PR DESCRIPTION
### Motivation
- The manually-triggered SDK regeneration job defined restrictive job-level `permissions` and omitted the package scope, which prevented the GitHub token from installing the private `@passiv/konfig-cli` package from GitHub Packages when running the reusable workflow.

### Description
- Add `packages: read` to the `permissions` block for the `regenerate-sdks-manual` job in `/.github/workflows/regenerate-sdks-manual.yaml` so the token can access GitHub Packages during manual SDK regeneration.

### Testing
- Ran `git diff --check` and `git status --short` locally after the change, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a42adcb0ad48328bd36a1118a2f6555)