### PR TITLE
Docs: remove Personal OAuth, standardize on signed-request auth, and update request-signature examples

### DIFF
--- a/docs/authentication-methods.md
+++ b/docs/authentication-methods.md
@@ -1,6 +1,6 @@
 # Authentication Methods
 
-We currently support three authentication methods. Choose the method based on whether the caller is a Commercial app acting for its own end users, or a Personal user managing their own brokerage accounts through their SnapTrade account.
+We currently support two signed-request authentication methods. Choose the method based on whether the caller is a Commercial app acting for its own end users, or a Personal user managing their own brokerage accounts through their SnapTrade account.
 
 :::info
 The current SDKs and parts of the API reference still describe **Commercial** authentication. Updates to the API reference and SDKs will follow shortly. Until then, use the rules below as the source of truth for which credentials to send.
@@ -14,7 +14,6 @@ If you'd like to try early SDK support, you can use the TypeScript SDK `11.0.0-c
 | --- | --- | --- | --- |
 | Commercial app authentication | Apps managing many end users | `clientId`, `consumerKey`, `userId`, `userSecret` | The `userId` and `userSecret` identify one SnapTrade user under the Commercial app |
 | Personal API key authentication | SnapTrade Personal accounts using signed API requests for connected brokerage accounts | `clientId`, `consumerKey` | The Personal API key identifies the account owner |
-| Personal OAuth authentication | Apps or connectors where the account owner signs in with their SnapTrade Personal account | OAuth access token | The Bearer token identifies the account owner |
 
 For a broader product-model comparison, see [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial).
 
@@ -76,47 +75,14 @@ Do not call :api[Authentication_registerSnapTradeUser] for Personal API key auth
 
 For more context on Personal API keys, see [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial). For signing direct API requests, see [Request Signatures](https://docs.snaptrade.com/docs/request-signatures).
 
-## Personal OAuth Authentication
-
-Use Personal OAuth authentication when the account owner signs in with their SnapTrade Personal account and grants your app access to their brokerage accounts with an OAuth access token.
-
-With this method, API requests use the OAuth access token as a Bearer token. Do not send `clientId`, `consumerKey`, `userId`, or `userSecret` in the API request.
-
-Direct API requests using this method include:
-
-- `Authorization: Bearer <access_token>` as a request header.
-- No `clientId`.
-- No `consumerKey`.
-- No `userId`.
-- No `userSecret`.
-- No request `Signature` header.
-
-Example request shape:
-
-```http
-GET /api/v1/accounts
-Authorization: Bearer <access_token>
-```
-
-:::info
-The API reference may still show API key fields, `userId`, or `userSecret` for endpoints that support Personal OAuth. For Bearer token requests, omit those fields and send only the OAuth access token in the `Authorization` header.
-:::
-
-The Bearer token identifies the account owner and scopes what the caller can do. Store access tokens securely and treat them as sensitive credentials.
-
-Personal OAuth follows the OAuth 2.0 authorization code flow with PKCE. OAuth clients can discover our current OAuth metadata at `https://api.snaptrade.com/.well-known/oauth-authorization-server`, including the authorization, token, introspection, revocation, and client registration endpoints.
-
 ## Choosing a Method
 
 Use Commercial app authentication if your backend owns the integration and maps many app users to SnapTrade users. This is the only method that requires your app to manage `userId` and `userSecret`.
 
 Use Personal API key authentication if you are using a SnapTrade Personal account and are comfortable with signed API requests.
 
-Use Personal OAuth authentication if the caller should never handle a `consumerKey`, `userId`, or `userSecret`, or if the access should be delegated through user consent.
-
 ## Related
 
 - [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial)
 - [Getting Started with SnapTrade](https://docs.snaptrade.com/docs/getting-started)
 - [Request Signatures](https://docs.snaptrade.com/docs/request-signatures)
-- [SnapTrade MCP Server](https://docs.snaptrade.com/docs/mcp-server)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ If you want a quick definitions reference while reading, see [Terminology](https
 
 If you are unsure whether to build as an individual user or as an app with many end users, see [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial).
 
-For a focused reference on Commercial credentials, Personal API keys, and Personal OAuth, see [Authentication Methods](https://docs.snaptrade.com/docs/authentication-methods).
+For a focused reference on Commercial credentials and Personal API keys, see [Authentication Methods](https://docs.snaptrade.com/docs/authentication-methods).
 
 Please see the FAQ of each section, as any questions you might have should be answered there.
 

--- a/docs/personal-vs-commercial.md
+++ b/docs/personal-vs-commercial.md
@@ -5,7 +5,7 @@ SnapTrade supports two primary customer experiences: **Personal** and **Commerci
 Use this guide to choose the right integration model before building authentication, user registration, connection management, billing, and support flows.
 
 :::info
-Personal and Commercial are customer experiences, not billing plan names. Billing plans such as Free, Pay-as-you-go, and Custom control limits, pricing, and feature availability. A customer's Personal or Commercial experience controls how SnapTrade users, credentials, OAuth, and Connection Portal flows behave.
+Personal and Commercial are customer experiences, not billing plan names. Billing plans such as Free, Pay-as-you-go, and Custom control limits, pricing, and feature availability. A customer's Personal or Commercial experience controls how SnapTrade users, credentials, and Connection Portal flows behave.
 :::
 
 ## Quick Comparison
@@ -15,9 +15,9 @@ Personal and Commercial are customer experiences, not billing plan names. Billin
 | Intended user | An individual using SnapTrade for their own brokerage accounts | A company building an app for its own end users |
 | SnapTrade account owner | The individual investor | The developer, company, or partner |
 | End-user model | The signed-in Personal user is the SnapTrade user | Your app creates one SnapTrade `userId` and `userSecret` per end user |
-| Authentication options | Personal OAuth, or Personal client ID and consumer key | Commercial client ID and consumer key |
-| API authorization | OAuth Bearer token for Personal OAuth, or signed requests with a Personal consumer key | Signed requests using the Commercial consumer key |
-| User registration | Do not call :api[Authentication_registerSnapTradeUser] for Personal OAuth | Call :api[Authentication_registerSnapTradeUser] before creating connections |
+| Authentication options | Personal client ID and consumer key | Commercial client ID and consumer key |
+| API authorization | Signed requests with a Personal consumer key | Signed requests using the Commercial consumer key |
+| User registration | Do not call :api[Authentication_registerSnapTradeUser] for Personal API key authentication | Call :api[Authentication_registerSnapTradeUser] before creating connections |
 | Connection Portal | Opens for the Personal user's own brokerage connections | Opens for a specific SnapTrade user managed by your app |
 | MCP server | Supported; the MCP server is designed for SnapTrade Personal users | Not used with Commercial developer API keys |
 | Key lifecycle | Personal customers can create one Personal client ID and consumer key in the dashboard | Commercial customers start with a test key and can create production keys after KYC approval |
@@ -34,18 +34,14 @@ Common Personal use cases include:
 - Portfolio analysis and trading for the user's own accounts.
 - Connection management for the user's own brokerages.
 
-Personal OAuth is the preferred pattern when your app should not handle SnapTrade API credentials directly. The user signs in with SnapTrade, your app receives OAuth tokens, and API calls are scoped to that Personal user.
+Personal client ID and consumer key authentication is available for Personal users who need signed-request workflows, including trading with their own accounts where enabled. The Personal user represents themselves. Unlike a Commercial integration, your app should not create a separate SnapTrade user for them.
 
-For Personal OAuth:
+For Personal API key authentication:
 
-- Use authorization code with PKCE.
-- Store OAuth tokens securely.
+- Sign requests with the Personal `consumerKey`.
 - Do not create a SnapTrade user with :api[Authentication_registerSnapTradeUser].
 - Do not store or send a `userSecret`.
-- Omit `userId` and `userSecret` when opening the Connection Portal; the Bearer token identifies the Personal user.
-- Treat the current `read` scope as account data and connection management, not trade placement or order modification.
-
-Personal client ID and consumer key authentication is available for Personal users who need signed-request workflows, including trading with their own accounts where enabled. In that case, the user still represents themselves. Unlike a Commercial integration, your app should not create a separate SnapTrade user for them.
+- Omit `userId` and `userSecret` when making API requests; SnapTrade resolves the user from the Personal API key.
 
 ## Choose Commercial When
 
@@ -96,9 +92,9 @@ The biggest implementation difference is whether your app creates SnapTrade user
 
 ### Personal
 
-With Personal OAuth, the OAuth token identifies the SnapTrade user. Your app can call normal SnapTrade APIs, but user identity is inferred from the token. Do not call user-registration endpoints or store a `userSecret`.
+With Personal API key authentication, the Personal API key identifies the SnapTrade user. Your app can call normal SnapTrade APIs, but user identity is inferred from the key. Do not call user-registration endpoints or store a `userSecret`.
 
-When opening the Connection Portal for a Personal OAuth user, generate the portal link without `userId` or `userSecret`. SnapTrade resolves the Personal user's context from the Bearer token.
+When opening the Connection Portal for a Personal API key user, generate the portal link without `userId` or `userSecret`. SnapTrade resolves the Personal user's context from the API key.
 
 ### Commercial
 
@@ -118,20 +114,12 @@ Feature availability depends on the customer, key, brokerage, account, and plan.
 
 Personal users can trade with their own accounts using SnapTrade client ID and consumer key authentication where trading is enabled for the account and brokerage.
 
-For Personal OAuth, the current `read` scope supports account data and connection-management workflows. Trading and other write operations require SnapTrade client ID and consumer key authentication where enabled.
-
 For Commercial integrations, trading requires:
 
 - A Commercial key with trading features enabled.
 - A brokerage and account that support trading.
 - A connection created with the appropriate connection type.
 - Your application's own user confirmation and compliance flow before submitting orders.
-
-## MCP And AI Connectors
-
-The SnapTrade MCP server is a Personal experience. It lets AI assistants read a Personal user's connected brokerage data after the user signs in with SnapTrade OAuth and approves read access.
-
-Commercial developer API keys are not used with the hosted MCP server. If you are building a Commercial product that includes AI features, your backend should use your Commercial integration model and expose only the user-facing AI behavior you intend to support.
 
 ## Billing And Limits
 
@@ -154,9 +142,9 @@ For Commercial integrations, design your onboarding, usage tracking, and support
 Before building, decide:
 
 - Is the person connecting accounts the SnapTrade customer, or is your company the SnapTrade customer?
-- Will users sign in with SnapTrade OAuth, or will your backend sign API requests with a consumer key?
+- Will your backend sign API requests with a consumer key?
 - Should your app call :api[Authentication_registerSnapTradeUser]?
-- Where will credentials, OAuth tokens, and user secrets be stored?
+- Where will credentials and user secrets be stored?
 - Who owns support for reconnecting brokerages and removing connections?
 - If you are building a Commercial integration, which billing plan controls limits, data freshness, and feature access?
 
@@ -167,6 +155,5 @@ If the user owns the SnapTrade account, use the Personal model. If your app owns
 - [Getting Started with SnapTrade](https://docs.snaptrade.com/docs/getting-started)
 - [Authentication Methods](https://docs.snaptrade.com/docs/authentication-methods)
 - [Terminology](https://docs.snaptrade.com/docs/terminology)
-- [SnapTrade MCP Server](https://docs.snaptrade.com/docs/mcp-server)
 - [Billing](https://docs.snaptrade.com/docs/billing)
 - [Request Signatures](https://docs.snaptrade.com/docs/request-signatures)

--- a/docs/request-signatures.md
+++ b/docs/request-signatures.md
@@ -28,16 +28,21 @@ The signature payload is a JSON object with exactly three fields:
 Example request:
 
 ```http
-GET /api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456
+POST /api/v1/symbols?clientId=YOUR_CLIENT_ID&timestamp=1715123456
 Signature: <generated_signature>
+Content-Type: application/json
+
+{"substring":"AAPL"}
 ```
 
 The signature payload for this request is:
 
 ```json
 {
-  "content": null,
-  "path": "/api/v1/accounts",
+  "content": {
+    "substring": "AAPL"
+  },
+  "path": "/api/v1/symbols",
   "query": "clientId=YOUR_CLIENT_ID&timestamp=1715123456"
 }
 ```
@@ -56,13 +61,13 @@ Use these rules:
 The canonical signature string for the example above is:
 
 ```json
-{"content":null,"path":"/api/v1/accounts","query":"clientId=YOUR_CLIENT_ID&timestamp=1715123456"}
+{"content":{"substring":"AAPL"},"path":"/api/v1/symbols","query":"clientId=YOUR_CLIENT_ID&timestamp=1715123456"}
 ```
 
 The following string represents the same JSON object, but it is not valid for signing because it contains extra whitespace:
 
 ```json
-{"content": null, "path": "/api/v1/accounts", "query": "clientId=YOUR_CLIENT_ID&timestamp=1715123456"}
+{"content": {"substring": "AAPL"}, "path": "/api/v1/symbols", "query": "clientId=YOUR_CLIENT_ID&timestamp=1715123456"}
 ```
 
 Cryptographic signatures are generated from the exact bytes of the string. Even small formatting differences will produce a different signature.
@@ -74,7 +79,7 @@ The `query` value is the exact query string sent in the request URL, excluding t
 Example:
 
 ```text
-/api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456
+/api/v1/symbols?clientId=YOUR_CLIENT_ID&timestamp=1715123456
 ```
 
 Use:
@@ -85,15 +90,18 @@ clientId=YOUR_CLIENT_ID&timestamp=1715123456
 
 Do not sort, decode, re-encode, or otherwise modify query parameters before signing.
 
-For requests without body, set `content` to `null`. This includes GET requests, bodyless DELETE/POST requests, and requests where the body would otherwise be `{}`.
+For requests without a body, set `content` to `null`. This includes GET requests, bodyless DELETE/POST requests, and requests where the body would otherwise be `{}`.
 
 ## End-to-End Example
 
-This example signs a direct API request for the account list endpoint. Replace `YOUR_CLIENT_ID` and `YOUR_CONSUMER_KEY` with your API key values. If your request includes additional query parameters, include those exact parameters in the URL and in the signature payload's `query` value.
+This example signs a direct API request for the symbol search endpoint. Replace `YOUR_CLIENT_ID` and `YOUR_CONSUMER_KEY` with your API key values. If your request includes additional query parameters, include those exact parameters in the URL and in the signature payload's `query` value.
 
 ```http
-GET /api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456
+POST /api/v1/symbols?clientId=YOUR_CLIENT_ID&timestamp=1715123456
 Signature: <generated_signature>
+Content-Type: application/json
+
+{"substring":"AAPL"}
 ```
 
 ### Python Example
@@ -121,8 +129,9 @@ def compute_request_signature(path: str, consumer_key: str, body: typing.Any = N
 
 
 query = urlencode({"clientId": "YOUR_CLIENT_ID", "timestamp": int(time.time())})
-resource_path = f"/accounts?{query}"
-signature = compute_request_signature(resource_path, "YOUR_CONSUMER_KEY")
+resource_path = f"/symbols?{query}"
+request_body = {"substring": "AAPL"}
+signature = compute_request_signature(resource_path, "YOUR_CONSUMER_KEY", request_body)
 ```
 
 ### TypeScript Example (Node.js)
@@ -154,14 +163,16 @@ const clientId = "YOUR_CLIENT_ID";
 const consumerKey = "YOUR_CONSUMER_KEY";
 const timestamp = Math.floor(Date.now() / 1000);
 
-const requestPath = "/api/v1/accounts";
+const requestPath = "/api/v1/symbols";
 const requestQuery = new URLSearchParams({
   clientId,
   timestamp: timestamp.toString(),
 }).toString();
 
+const requestData = { substring: "AAPL" };
+
 const sigObject = {
-  content: null,
+  content: requestData,
   path: requestPath,
   query: requestQuery,
 };
@@ -198,9 +209,10 @@ public class Example {
         String consumerKey = "YOUR_CONSUMER_KEY";
         long timestamp = System.currentTimeMillis() / 1000L;
 
-        String path = "/api/v1/accounts";
+        String path = "/api/v1/symbols";
         String queryString = "clientId=" + clientId + "&timestamp=" + timestamp;
-        String data = String.format("{\"content\":null,\"path\":\"%s\",\"query\":\"%s\"}", path, queryString);
+        String requestBody = "{\"substring\":\"AAPL\"}";
+        String data = String.format("{\"content\":%s,\"path\":\"%s\",\"query\":\"%s\"}", requestBody, path, queryString);
         String signature = encodeBase64(calculateHmacSha256(data, consumerKey));
     }
 }
@@ -235,14 +247,16 @@ func main() {
 	consumerKey := "YOUR_CONSUMER_KEY"
 	timestamp := time.Now().Unix()
 
-	requestPath := "/api/v1/accounts"
+	requestPath := "/api/v1/symbols"
 	query := url.Values{}
 	query.Set("clientId", clientId)
 	query.Set("timestamp", fmt.Sprintf("%d", timestamp))
 	requestQuery := query.Encode()
 
+	requestData := map[string]interface{}{"substring": "AAPL"}
+
 	sigObject := map[string]interface{}{
-		"content": nil,
+		"content": requestData,
 		"path":    requestPath,
 		"query":   requestQuery,
 	}
@@ -272,6 +286,9 @@ func main() {
 The same signing rules apply to every authentication mode that uses `clientId`, `timestamp`, and `Signature`. Sign the exact query string you send. For example, a request with additional query parameters signs those parameters as part of `query`:
 
 ```http
-GET /api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456&userId=YOUR_USER_ID&userSecret=YOUR_USER_SECRET
+POST /api/v1/symbols?clientId=YOUR_CLIENT_ID&timestamp=1715123456&userId=YOUR_USER_ID&userSecret=YOUR_USER_SECRET
 Signature: <generated_signature>
+Content-Type: application/json
+
+{"substring":"AAPL"}
 ```

--- a/docs/request-signatures.md
+++ b/docs/request-signatures.md
@@ -1,6 +1,6 @@
 # Request Signatures
 
-SnapTrade API requests are authenticated using your `clientId`, a Unix `timestamp`, and a `Signature` header.
+SnapTrade API requests made with a `clientId` and `consumerKey` are authenticated with a Unix `timestamp` query parameter and a `Signature` header.
 
 The official SnapTrade SDKs generate request signatures automatically. You only need to implement this flow manually if you are calling the SnapTrade API directly without an SDK.
 
@@ -8,11 +8,12 @@ The official SnapTrade SDKs generate request signatures automatically. You only 
 
 To generate a request signature:
 
-1. Build a signature payload containing the request body, path, and query string.
-2. Serialize the payload into canonical JSON.
-3. Sign the canonical JSON string using HMAC-SHA256 with your `consumerKey`.
-4. Base64-encode the HMAC digest.
-5. Send the encoded value in the `Signature` header.
+1. Add `clientId` and `timestamp` to the request query string.
+2. Build a signature payload containing the request body, path, and query string.
+3. Serialize the payload into canonical JSON.
+4. Sign the canonical JSON string using HMAC-SHA256 with your `consumerKey`.
+5. Base64-encode the HMAC digest.
+6. Send the encoded value in the `Signature` header.
 
 ## Signature Payload
 
@@ -27,22 +28,17 @@ The signature payload is a JSON object with exactly three fields:
 Example request:
 
 ```http
-POST /api/v1/snapTrade/registerUser?clientId=PASSIVTEST&timestamp=1635790389
+GET /api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456
 Signature: <generated_signature>
-Content-Type: application/json
-
-{"userId":"new_user_123"}
 ```
 
 The signature payload for this request is:
 
 ```json
 {
-  "content": {
-    "userId": "new_user_123"
-  },
-  "path": "/api/v1/snapTrade/registerUser",
-  "query": "clientId=PASSIVTEST&timestamp=1635790389"
+  "content": null,
+  "path": "/api/v1/accounts",
+  "query": "clientId=YOUR_CLIENT_ID&timestamp=1715123456"
 }
 ```
 
@@ -60,13 +56,13 @@ Use these rules:
 The canonical signature string for the example above is:
 
 ```json
-{"content":{"userId":"new_user_123"},"path":"/api/v1/snapTrade/registerUser","query":"clientId=PASSIVTEST&timestamp=1635790389"}
+{"content":null,"path":"/api/v1/accounts","query":"clientId=YOUR_CLIENT_ID&timestamp=1715123456"}
 ```
 
 The following string represents the same JSON object, but it is not valid for signing because it contains extra whitespace:
 
 ```json
-{"content": {"userId": "new_user_123"}, "path": "/api/v1/snapTrade/registerUser", "query": "clientId=PASSIVTEST&timestamp=1635790389"}
+{"content": null, "path": "/api/v1/accounts", "query": "clientId=YOUR_CLIENT_ID&timestamp=1715123456"}
 ```
 
 Cryptographic signatures are generated from the exact bytes of the string. Even small formatting differences will produce a different signature.
@@ -78,18 +74,27 @@ The `query` value is the exact query string sent in the request URL, excluding t
 Example:
 
 ```text
-/api/v1/snapTrade/registerUser?clientId=PASSIVTEST&timestamp=1635790389
+/api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456
 ```
 
 Use:
 
 ```text
-clientId=PASSIVTEST&timestamp=1635790389
+clientId=YOUR_CLIENT_ID&timestamp=1715123456
 ```
 
 Do not sort, decode, re-encode, or otherwise modify query parameters before signing.
 
 For requests without body, set `content` to `null`. This includes GET requests, bodyless DELETE/POST requests, and requests where the body would otherwise be `{}`.
+
+## End-to-End Example
+
+This example signs a direct API request for the account list endpoint. Replace `YOUR_CLIENT_ID` and `YOUR_CONSUMER_KEY` with your API key values. If your request includes additional query parameters, include those exact parameters in the URL and in the signature payload's `query` value.
+
+```http
+GET /api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456
+Signature: <generated_signature>
+```
 
 ### Python Example
 
@@ -98,11 +103,13 @@ from base64 import b64encode
 import hashlib
 import hmac
 import json
+import time
 import typing
+from urllib.parse import urlencode
 
 
-def compute_request_signature(path: str, consumer_key: str, body: typing.Any) -> str:
-    subpath, query = path.split("?")
+def compute_request_signature(path: str, consumer_key: str, body: typing.Any = None) -> str:
+    subpath, query = path.split("?", 1)
     sig_object = {
         "content": None if body is None or body == {} else body,
         "path": "/api/v1%s" % subpath,
@@ -113,10 +120,9 @@ def compute_request_signature(path: str, consumer_key: str, body: typing.Any) ->
     return b64encode(sig_digest).decode()
 
 
-resource_path = "/snapTrade/registerUser?clientId=PASSIVTEST&timestamp=1635790389"
-request_body = {"userId": "new_user_123"}
-
-signature = compute_request_signature(resource_path, "YOUR_CONSUMER_KEY", request_body)
+query = urlencode({"clientId": "YOUR_CLIENT_ID", "timestamp": int(time.time())})
+resource_path = f"/accounts?{query}"
+signature = compute_request_signature(resource_path, "YOUR_CONSUMER_KEY")
 ```
 
 ### TypeScript Example (Node.js)
@@ -144,14 +150,18 @@ function computeHmacSha256(message: string, key: string): string {
   return hmac.digest("base64");
 }
 
-const consumerKey = encodeURI("YOUR_CONSUMER_KEY");
+const clientId = "YOUR_CLIENT_ID";
+const consumerKey = "YOUR_CONSUMER_KEY";
+const timestamp = Math.floor(Date.now() / 1000);
 
-const requestData = { userId: "new_user_123" };
-const requestPath = "/api/v1/snapTrade/registerUser";
-const requestQuery = "clientId=PASSIVTEST&timestamp=1635790389";
+const requestPath = "/api/v1/accounts";
+const requestQuery = new URLSearchParams({
+  clientId,
+  timestamp: timestamp.toString(),
+}).toString();
 
 const sigObject = {
-  content: requestData,
+  content: null,
   path: requestPath,
   query: requestQuery,
 };
@@ -163,14 +173,12 @@ const signature = computeHmacSha256(sigContent, consumerKey);
 ### Java Example
 
 ```java
-import com.google.gson.Gson;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
-import java.util.TreeMap;
 
 public class Example {
     private static byte[] calculateHmacSha256(String message, String key)
@@ -186,16 +194,14 @@ public class Example {
     }
 
     public static void main(String[] args) throws NoSuchAlgorithmException, InvalidKeyException {
-        Gson gson = new Gson();
-        String payload = "{\"userId\":\"new_user_123\"}";
-        String path = "/snapTrade/registerUser";
-        String queryString = "clientId=PASSIVTEST&timestamp=1635790389";
-        Object map = gson.fromJson(payload, TreeMap.class);
-        String sortedJson = map == null ? "\"\"" : gson.toJson(map);
-        String data = String.format("{\"content\":%s,\"path\":\"/api/v1%s\",\"query\":\"%s\"}",
-                payload == null || payload.equals("") || payload.equals("{}") ? "null" : sortedJson, path,
-                queryString);
-        String signature = encodeBase64(calculateHmacSha256(data, "YOUR_CONSUMER_KEY"));
+        String clientId = "YOUR_CLIENT_ID";
+        String consumerKey = "YOUR_CONSUMER_KEY";
+        long timestamp = System.currentTimeMillis() / 1000L;
+
+        String path = "/api/v1/accounts";
+        String queryString = "clientId=" + clientId + "&timestamp=" + timestamp;
+        String data = String.format("{\"content\":null,\"path\":\"%s\",\"query\":\"%s\"}", path, queryString);
+        String signature = encodeBase64(calculateHmacSha256(data, consumerKey));
     }
 }
 ```
@@ -211,8 +217,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"sort"
 	"strings"
+	"time"
 )
 
 func computeHmacSha256(message string, key string) string {
@@ -222,12 +231,18 @@ func computeHmacSha256(message string, key string) string {
 }
 
 func main() {
-	requestData := map[string]interface{}{"userId": "new_user_123"}
-	requestPath := "/api/v1/snapTrade/registerUser"
-	requestQuery := "clientId=PASSIVTEST&timestamp=1635790389"
+	clientId := "YOUR_CLIENT_ID"
+	consumerKey := "YOUR_CONSUMER_KEY"
+	timestamp := time.Now().Unix()
+
+	requestPath := "/api/v1/accounts"
+	query := url.Values{}
+	query.Set("clientId", clientId)
+	query.Set("timestamp", fmt.Sprintf("%d", timestamp))
+	requestQuery := query.Encode()
 
 	sigObject := map[string]interface{}{
-		"content": requestData,
+		"content": nil,
 		"path":    requestPath,
 		"query":   requestQuery,
 	}
@@ -247,7 +262,16 @@ func main() {
 	encoder.SetEscapeHTML(false)
 	encoder.Encode(sortedSigObject)
 
-	signature := computeHmacSha256(strings.TrimSuffix(sigContent.String(), "\n"), "YOUR_CONSUMER_KEY")
+	signature := computeHmacSha256(strings.TrimSuffix(sigContent.String(), "\n"), consumerKey)
 	_ = signature
 }
+```
+
+## Query Parameters
+
+The same signing rules apply to every authentication mode that uses `clientId`, `timestamp`, and `Signature`. Sign the exact query string you send. For example, a request with additional query parameters signs those parameters as part of `query`:
+
+```http
+GET /api/v1/accounts?clientId=YOUR_CLIENT_ID&timestamp=1715123456&userId=YOUR_USER_ID&userSecret=YOUR_USER_SECRET
+Signature: <generated_signature>
 ```

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -7,7 +7,7 @@ Aliases: app credentials, integration credentials
 Learn more: [Getting Started: API Keys](https://docs.snaptrade.com/docs/getting-started#getting-started-api-keys), [Authentication Methods](https://docs.snaptrade.com/docs/authentication-methods), [FAQ: API Keys](https://docs.snaptrade.com/docs/faq#faq-api-keys)
 
 ## Personal Customer
-A free SnapTrade customer experience for individuals who connect and manage their own brokerage accounts. Personal users can use SnapTrade OAuth or a Personal client ID and consumer key.
+A free SnapTrade customer experience for individuals who connect and manage their own brokerage accounts. Personal users can use a Personal client ID and consumer key.
 
 Learn more: [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial)
 


### PR DESCRIPTION
### Motivation

- Consolidate authentication guidance by removing Personal OAuth references and clarifying that SnapTrade supports two signed-request authentication modes (Commercial and Personal API key). 
- Make the request signature flow clearer and provide up-to-end examples across languages for direct API calls that use `clientId`, `timestamp`, and `Signature`.

### Description

- Updated `docs/authentication-methods.md` to state there are two signed-request authentication methods and removed the Personal OAuth section. 
- Adjusted `docs/personal-vs-commercial.md` and `docs/getting-started.md` to remove Personal OAuth guidance and to clarify Personal API key usage and when to call `:api[Authentication_registerSnapTradeUser]`. 
- Rewrote `docs/request-signatures.md` to require adding `clientId` and `timestamp` to the query string before building the signature payload, added an end-to-end example, and expanded language-specific examples (Python, TypeScript, Java, Go) to generate signatures using the updated query handling. 
- Added a `Query Parameters` section explaining how to include additional query parameters (for example `userId` and `userSecret`) in the signed `query` string. 
- Minor terminology cleanup in `docs/terminology.md` to remove OAuth references for Personal customers.

### Testing

- Ran markdown linting (`markdownlint`) against the changed files and the linter returned no errors. 
- Built the documentation site (`npm run build`) and ran link checks, both of which completed successfully. 
- No application code or unit tests were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4bca6d6fc48328a4e4869dae62472f)