### PR TITLE
fix: data_freshness_mode docs

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -5761,7 +5761,7 @@ components:
             - realtime
             - delayed
 
-            Indicates whether SnapTrade will provide delayed or realtime data for this connection. `delayed` means SnapTrade uses cached data for the connection because of the customer's plan, or because of brokerage limitations. `realtime` means SnapTrade retrieves current data from the brokerage during API calls. See the "Cache Expiry of Holdings" column on the Holdings tab at https://support.snaptrade.com/brokerages for which val
+            Indicates whether SnapTrade will provide delayed or realtime data for this connection. `delayed` means SnapTrade uses cached data for the connection because of the customer's plan, or because of brokerage limitations. `realtime` means SnapTrade retrieves current data from the brokerage during API calls. See the "Cache Expiry of Holdings" column on the Holdings tab at https://support.snaptrade.com/brokerages to understand whether holdings data is cached for a brokerage.
           type: string
           example: realtime
     BrokerageAuthorizationRefreshConfirmation:


### PR DESCRIPTION
## Summary

Fixes the truncated `data_freshness_mode` description in `api.yaml`.

## Details

The field documentation previously ended mid-sentence at `for which val`. This completes the sentence by pointing readers to the Holdings tab's `Cache Expiry of Holdings` column on the SnapTrade brokerage support page to understand whether holdings data is cached for a brokerage.

Per request, this PR only changes the source OpenAPI spec file, `api.yaml`.

## Validation

- `git diff --check`
- Confirmed no remaining `for which val` / `which val` truncation in the edited source text before committing.