### PR TITLE
Fix Connection Portal 'Initialising' formatting

### DIFF
--- a/docs/implement-connection-portal.md
+++ b/docs/implement-connection-portal.md
@@ -17,35 +17,21 @@ SnapTrade’s connection portal is built to run smoothly on all modern browsers 
 - Native Android
 - React Native
 
-### Initializing
+### Initialising
 
 The SnapTrade connection flow begins when your user shows intent to connect their brokerage account to your app.
 
-1
+1. User taps _Connect Account_ in your app.
 
-User taps _Connect Account_ in your app.
+   Your app calls your backend to generate a SnapTrade connection portal login link and returns it to the client.
 
-Your app calls your backend to generate a SnapTrade connection portal login link and returns it to the client.
+2. Your app opens the SnapTrade connection portal login link for the user (see [Integration Methods for platform-specific best practices](#integration-methods)).
 
----
+   They select their brokerage and go through the login flow.
 
-2
+3. After successfully connecting, SnapTrade redirects the user back to your app.
 
-Your app opens the SnapTrade connection portal login link for the user (see [Integration Methods for platform-specific best practices](#integration-methods)).
-
-They select their brokerage and go through the login flow.
-
----
-
-3
-
-After successfully connecting, SnapTrade redirects the user back to your app.
-
----
-
-4
-
-Your backend can now fetch and store the connection details and use them to make necessary API requests for the user.
+4. Your backend can now fetch and store the connection details and use them to make necessary API requests for the user.
 
 ### Login Link Parameters
 


### PR DESCRIPTION
### Motivation
- The Connection Portal "Initialising" section contained standalone number lines and horizontal dividers that prevented the four-step flow from rendering as a single ordered list.
- Make the flow easier to read and consistent with the rest of the docs by converting it to a proper Markdown ordered list and preserving existing explanatory text.

### Description
- Converted the four standalone numbered lines and divider separators into a single ordered list with inline step text and indented explanatory paragraphs so the steps render correctly.
- Normalised the section header to `### Initialising` and preserved all original content and links under the appropriate steps.
- Modified `docs/implement-connection-portal.md` only, leaving other files unchanged.

### Testing
- Ran `git diff --check -- docs/implement-connection-portal.md` and the check returned no formatting issues.
- Confirmed the reformatted section renders as a contiguous ordered list when viewed as Markdown.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a510374d0b48328bebc3e6bc5b62a48)