### PR TITLE
docs(mcp-server): update Claude connector setup steps to new UI

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -66,18 +66,14 @@ For details on what data the connector accesses and how it is handled, see the [
 9. Claude redirects you to SnapTrade. If prompted, log in, then click **Allow access** to approve **read** access to your account data.
 10. After you approve, you are returned to Claude and the SnapTrade tools become available.
 
-## Set up the connector in ChatGPT
+## Set up the SnapTrade app in ChatGPT
 
-1. In ChatGPT, go to **Settings → Apps & Connectors → Advanced settings** and turn on **Developer mode**.
-2. Go to **Settings → Connectors** and click **Create**.
+1. In ChatGPT, go to **Settings → Security and login → Developer mode** and turn on **Developer mode**.
+2. Go to **Settings → Plugins** and click **+** to create a developer-mode app.
 3. Enter a name (for example, `SnapTrade`) and the MCP server URL: `https://mcp.snaptrade.com/mcp`.
-4. Set the authentication method to **OAuth** and confirm you trust the application.
-5. Click **Create**, then complete the OAuth login flow with SnapTrade and approve **read** access.
-6. After you approve, the SnapTrade tools become available in your chats.
-
-> Note: ChatGPT Developer mode and custom connectors are available on ChatGPT for web, not the desktop app — complete this setup at [chatgpt.com](https://chatgpt.com).
-
-> Note: Once the SnapTrade app is approved in the ChatGPT app directory, users can add it directly from the directory without enabling Developer mode.
+4. Set authentication to **OAuth**, then create the app.
+5. Complete the SnapTrade login flow and approve **read** access.
+6. In a new chat, click **+ → More → SnapTrade** to enable the SnapTrade app connected through MCP.
 
 ## Example prompts
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -55,12 +55,16 @@ For details on what data the connector accesses and how it is handled, see the [
 
 ## Set up the connector in Claude
 
-1. In Claude, go to **Customize → Connectors**.
-2. Click **+**, then **Add custom connector**.
-3. Enter the MCP server URL: `https://mcp.snaptrade.com/mcp`.
-4. Claude redirects you to SnapTrade. Log in and approve **read** access to your account data.
-5. Review the consent screen, which lists the read-only scope being granted.
-6. After you approve, you are returned to Claude and the SnapTrade tools become available.
+1. In Claude, open **Settings**.
+2. Go to **Connectors**.
+3. Click **Add**.
+4. Click **Add custom connector**.
+5. Enter a name (for example, `SnapTrade`).
+6. Enter the MCP server URL: `https://mcp.snaptrade.com/mcp`.
+7. Click **Add**.
+8. Click **Connect**.
+9. Claude redirects you to SnapTrade. If prompted, log in, then click **Allow access** to approve **read** access to your account data.
+10. After you approve, you are returned to Claude and the SnapTrade tools become available.
 
 ## Set up the connector in ChatGPT
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -69,11 +69,11 @@ For details on what data the connector accesses and how it is handled, see the [
 ## Set up the SnapTrade app in ChatGPT
 
 1. In ChatGPT, go to **Settings → Security and login → Developer mode** and turn on **Developer mode**.
-2. Go to **Settings → Plugins** and click **+** to create a developer-mode app.
+2. Go to **Settings → Plugins → Browse plugins** and click **+** to create a developer-mode app.
 3. Enter a name (for example, `SnapTrade`) and the MCP server URL: `https://mcp.snaptrade.com/mcp`.
 4. Set authentication to **OAuth**, then create the app.
 5. Complete the SnapTrade login flow and approve **read** access.
-6. In a new chat, click **+ → More → SnapTrade** to enable the SnapTrade app connected through MCP.
+6. In a new chat, mention SnapTrade or tag **@SnapTrade** to access your SnapTrade data through MCP.
 
 ## Example prompts
 


### PR DESCRIPTION
### Motivation
- Update the Claude setup instructions to match the current UI and step sequence for adding a custom connector.

### Description
- Replace the previous numbered steps with an updated sequence that instructs users to open `Settings`, go to `Connectors`, click `Add` then `Add custom connector`, enter a name and the MCP server URL `https://mcp.snaptrade.com/mcp`, click `Add` and `Connect`, and complete the OAuth flow to approve read access.

### Testing
- No automated tests were run since this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57abedbfb88328974a3ac64daf8823)