### PR TITLE
Clarify real-time and daily data plans

### DIFF
--- a/docs/realtime-data.md
+++ b/docs/realtime-data.md
@@ -1,32 +1,38 @@
-# Best practices to serve real-time data
+# Real-time vs Daily plans
 
-SnapTrade offers the ability to get real-time data on both Pay as you Go / Real-time and Pay as you Go / Daily plans. Real-time requests are enabled by default on all non-custom plans. See [our pricing page](https://snaptrade.com/pricing) for more information on plans
+SnapTrade offers two data freshness options for holdings data: **Real-time** and **Daily**. These names describe how data is refreshed; they are separate from your billing model. You can confirm which option your API key uses on the [Customer Dashboard billing page](https://dashboard.snaptrade.com/settings/billing).
 
-### Pay as you Go / Real-time
+| Behavior | Real-time | Daily |
+| --- | --- | --- |
+| Data returned | Supported holdings endpoints fetch the latest data from the brokerage when called. | Holdings data is cached and refreshed once per day. Exact refresh timing may vary by brokerage. |
+| Intraday updates | Call the holdings endpoints again to fetch updated brokerage data. | Call the [Refresh connection endpoint](https://docs.snaptrade.com/reference/Connections/Connections_refreshBrokerageAuthorization) to start an asynchronous update. Additional charges may apply. |
+| Completion signal | The API response contains the refreshed data. | Wait for an [ACCOUNT_HOLDINGS_UPDATED webhook](https://docs.snaptrade.com/docs/webhooks#webhooks-account_holdings_updated) for each account before requesting the updated holdings. |
 
-The best practice for showing users accurate data on Pay as you Go / Real-time is to update the relevant user context when the user logs in to your app. You can do this by making API calls to the resources you need, commonly [/positions/all](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getAllAccountPositions), [/balances](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountBalance). Repeat this process every 10 minutes while the user remains active in your application
+Holdings data includes positions, balances, orders, and account details. Data availability and freshness still depend on what each brokerage makes available.
 
-### Pay as you Go / Daily
+## Recommended application flow
 
-On Pay as you Go / Daily, SnapTrade returns Daily data. Daily data is cached and refreshed once a day. Exact refresh timing may vary by brokerage. To get real-time data we recommend calling [the manual refresh endpoint](https://docs.snaptrade.com/reference/Connections/Connections_refreshBrokerageAuthorization) to update the data. SnapTrade will begin a sync and notify you via [ACCOUNT_HOLDINGS_UPDATED](https://docs.snaptrade.com/docs/webhooks#webhooks-account_holdings_updated) webhooks when each account has finished syncing, at which point you can call [/positions/all](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getAllAccountPositions), [/balances](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountBalance) for each account. If you expect account owners to want intraday updates, it is a good idea to give the option of a refresh button that lets the user refresh their data in the same way. Note that calls to the Refresh endpoint will incur additional charges according to your plan
+### Real-time
 
+When a user logs in to your application, request the holdings data needed for their current view. Common endpoints include [List all account positions](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getAllAccountPositions) and [List account balances](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountBalance).
 
-## Get notified when users place trades at their broker
+While the user remains active, request the data again as needed. To avoid SnapTrade and brokerage rate limits, we recommend polling no more often than once every 10 minutes per account.
 
-If you need to know when a trade has been placed by a specific user, the recommendation is to poll the [Recent Orders endpoint](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountRecentOrders), only during market hours. This endpoint defaults to returning the last day of executed orders. Keep a copy of this list on your end, and check if a new order is present in the polling responses. To avoid SnapTrade and institution rate limits, we recommend polling at most once every 5 minutes per account. If faster trade detection is needed, please check out https://docs.snaptrade.com/docs/webhooks#webhooks-trade_detection and contact support@snaptrade.com if you wish to purchase a subscription (or reach out on discord/slack).
+### Daily
 
+Use the cached daily data for normal application loads. If users need an intraday update, consider providing a refresh button that calls the [Refresh connection endpoint](https://docs.snaptrade.com/reference/Connections/Connections_refreshBrokerageAuthorization).
+
+A refresh runs asynchronously. After starting it, wait for an [ACCOUNT_HOLDINGS_UPDATED webhook](https://docs.snaptrade.com/docs/webhooks#webhooks-account_holdings_updated) for each account, then request the updated positions, balances, and other holdings data. Each refresh call may incur an additional charge according to your plan.
 
 ## Transactions
-Please see [our guide on Syncing and Data Freshness](https://docs.snaptrade.com/docs/syncing) for more information about transactions
 
-## Relevant Endpoints 
+Transactions are cached, updated once per day, and delayed by one day on both Real-time and Daily plans. If you need intraday trade activity, use orders instead. See [Syncing and Data Freshness](https://docs.snaptrade.com/docs/syncing) and [Orders compared with activities](https://docs.snaptrade.com/docs/account-data#account-data-orders) for details.
 
-[List all account positions](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getAllAccountPositions)
+## Relevant endpoints
 
-[List account balances](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountBalance)
-
-[List account orders (all)](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountOrders)
-
-[List account recent orders (for polling)](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountRecentOrders)
-
-[Get account detail (total account value)](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountDetails)
+- [List all account positions](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getAllAccountPositions)
+- [List account balances](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountBalance)
+- [List account orders](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountOrders)
+- [List recent account orders](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountRecentOrders)
+- [Get account details](https://docs.snaptrade.com/reference/Account%20Information/AccountInformation_getUserAccountDetails)
+- [Refresh a connection](https://docs.snaptrade.com/reference/Connections/Connections_refreshBrokerageAuthorization)

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -1,36 +1,42 @@
 # Syncing and Data Freshness
 
-It's first important to understand whether you are on Pay as you Go / Real-time or Pay as you Go / Daily, which you can find in [the dashboard](https://dashboard.snaptrade.com/settings/billing). Note that [if the connection is disabled](https://docs.snaptrade.com/docs/fix-broken-connections), fresh data cannot be fetched on either plan until the connection is fixed.
-Daily data is cached and refreshed once a day. Exact refresh timing may vary by brokerage.
+First, confirm whether your API key uses the **Real-time** or **Daily** data freshness option on the [Customer Dashboard billing page](https://dashboard.snaptrade.com/settings/billing). See [Real-time vs Daily plans](https://docs.snaptrade.com/docs/realtime-data) for a comparison and recommended application flows.
 
-Pay as you Go / Real-time: holdings (positions, balances, orders) are fetched with every API request.
+If a [connection is disabled](https://docs.snaptrade.com/docs/fix-broken-connections), fresh data cannot be fetched on either plan until the connection is fixed.
 
-Pay as you Go / Daily: holdings are updated once per day with the daily sync.
+For both plans, transactions are cached, updated once per day with the daily sync, and delayed by one day. Intraday transactions are not available. If you need intraday trade activity, [compare orders with transactions](https://docs.snaptrade.com/docs/account-data#account-data-orders).
 
-For both plans, transactions are cached, updated once per day with the daily sync, and delayed by one day (no intraday transactions, [compare orders to transactions here](https://docs.snaptrade.com/docs/account-data#account-data-orders) if you need real-time trades).
+If you need to know when transactions—or holdings data on Daily plans—have synced, use webhooks or the account sync status.
 
-If you need to know when transactions (and holdings data on Daily data plans) are synced, there are two methods:
+## Webhooks
 
-Webhooks:
-- [ACCOUNT_TRANSACTIONS_UPDATED](https://docs.snaptrade.com/docs/webhooks#webhooks-account_transactions_updated) webhook will be sent when we create a new transaction for an account. Note that no webhook will be sent if we sync transactions and no new data is found.
-- [ACCOUNT_HOLDINGS_UPDATED](https://docs.snaptrade.com/docs/webhooks#webhooks-account_holdings_updated) will be sent once per day when holdings are updated (regardless of if data changes or not). This is only really helpful for Daily data since Pay as you Go / Real-time plans will update brokerage data with each request.
+- [ACCOUNT_TRANSACTIONS_UPDATED](https://docs.snaptrade.com/docs/webhooks#webhooks-account_transactions_updated) is sent when SnapTrade creates a new transaction for an account. No webhook is sent if a transaction sync finds no new data.
+- [ACCOUNT_HOLDINGS_UPDATED](https://docs.snaptrade.com/docs/webhooks#webhooks-account_holdings_updated) is sent once per day when holdings are updated, whether or not the data changed. This is primarily useful for Daily plans because Real-time plans refresh supported holdings data when it is requested.
 
-API Account Status:
-- [List accounts for a connection endpoint](https://docs.snaptrade.com/reference/Connections/Connections_listBrokerageAuthorizationAccounts) will return a `sync_status` object for each account in the connection. This tells you when the daily sync last ran for holdings, as well as the last day that transactions **have been fully synced** (transactions have been pulled from 00:00 to 23:59). If a user has multiple connections, first call :api[Connections_listBrokerageAuthorizations], then call :api[Connections_listBrokerageAuthorizationAccounts] for each connection.
-  ```
+## API account status
+
+[List accounts for a connection](https://docs.snaptrade.com/reference/Connections/Connections_listBrokerageAuthorizationAccounts) returns a `sync_status` object for each account. It reports when the daily holdings sync last ran and the last day for which transactions **have been fully synced** from 00:00 through 23:59.
+
+If a user has multiple connections, first call :api[Connections_listBrokerageAuthorizations], then call :api[Connections_listBrokerageAuthorizationAccounts] for each connection.
+
+```json
+{
   "sync_status": {
-      "transactions": {
-        "initial_sync_completed": true,
-        "last_successful_sync": "2022-01-24",
-        "first_transaction_date": "2022-01-24"
-      },
-      "holdings": {
-        "initial_sync_completed": true,
-        "last_successful_sync": "2024-06-28 18:42:46.561408+00:00"
-      }
+    "transactions": {
+      "initial_sync_completed": true,
+      "last_successful_sync": "2022-01-24",
+      "first_transaction_date": "2022-01-24"
     },
-  ```
+    "holdings": {
+      "initial_sync_completed": true,
+      "last_successful_sync": "2024-06-28 18:42:46.561408+00:00"
+    }
+  }
+}
+```
 
-If on Pay as you Go / Daily and a holdings update is needed, you can call [the Refresh connection endpoint](https://docs.snaptrade.com/reference/Connections/Connections_refreshBrokerageAuthorization). Please note that additional charges may apply to each of these calls, you can find pricing information in [the dashboard](https://dashboard.snaptrade.com/settings/billing).
+## Request an intraday holdings update
 
-If looking to control at what time of day transactions are updated, please reach out to the team about [a custom plan](https://snaptrade.com/pricing).
+On a Daily plan, call the [Refresh connection endpoint](https://docs.snaptrade.com/reference/Connections/Connections_refreshBrokerageAuthorization) when an intraday holdings update is needed. Additional charges may apply to each call; see the [Customer Dashboard billing page](https://dashboard.snaptrade.com/settings/billing) for pricing.
+
+If you need to control the time of day when transactions are updated, contact the SnapTrade team about [a custom plan](https://snaptrade.com/pricing).

--- a/docs/trade-detection.md
+++ b/docs/trade-detection.md
@@ -1,7 +1,7 @@
 # Trade Detection Subscriptions
 
 > **Summary**: Important behavior and integration details for SnapTrade `TRADE_DETECTION` webhook subscriptions.
-> **Related docs**: [Best practices to serve real-time data](./realtime-data), [TRADE_DETECTION webhook](./webhooks#webhooks-trade_detection)
+> **Related docs**: [Real-time vs Daily plans](./realtime-data), [TRADE_DETECTION webhook](./webhooks#webhooks-trade_detection)
 
 `TRADE_DETECTION` notifies partners when SnapTrade detects an executed order in a subscribed account. This feature is only supported for accounts where the brokerage supports realtime order updates. You can manage your subscriptions when logged in to the SnapTrade Dashboard at https://dashboard.snaptrade.com/webhooks
 


### PR DESCRIPTION
## Summary

- Reframe the existing real-time data guide as a comparison of Real-time and Daily data freshness plans while preserving its URL.
- Update the syncing guide to link to the plan comparison and focus on transaction timing, webhooks, account sync status, and manual refreshes.
- Render the `sync_status` example as a standalone, valid JSON code block.
- Update the related-doc label in the trade detection guide.

## Why

The previous `Pay as you Go / Real-time` and `Pay as you Go / Daily` wording mixed the billing model with the data freshness option and could read as mutually exclusive choices. The JSON example was also nested in list content in a way that caused it to render as inline text instead of a code block.

## Impact

Readers can now compare Real-time and Daily behavior directly, follow the appropriate refresh flow, and read or copy the account sync status example cleanly.

## Validation

- `git diff --check HEAD^`
- Confirmed `Pay as you Go` no longer appears in the two affected plan/syncing guides.
- Extracted the fenced JSON example and validated it with `jq empty`.
