### PR TITLE
Add hidden OpenBB SnapTrade widget guide

### DIFF
--- a/docs/openbb-snaptrade-widget.md
+++ b/docs/openbb-snaptrade-widget.md
@@ -1,0 +1,52 @@
+# OpenBB SnapTrade Widget
+
+The OpenBB SnapTrade widget connects your own brokerage accounts to OpenBB Workspace through [SnapTrade](https://snaptrade.com), so you can see your live holdings, balances, orders, and activity next to the rest of your research — plus let the Workspace AI agent answer questions about your real portfolio.
+
+---
+
+## 1. Create a SnapTrade account
+
+Sign up for a personal SnapTrade account at **https://dashboard.snaptrade.com/signup?personal=**.
+
+---
+
+## 2. Get your API keys
+
+Go to **https://dashboard.snaptrade.com/api-key**. Your key pair is already there:
+
+- **Client ID**
+- **Consumer key**
+
+Copy both — you'll paste them into Workspace in the next step.
+
+Treat these keys like a password: they unlock the brokerage accounts you connect. Don't share them, and don't put them into a Workspace instance other people can use.
+
+---
+
+## 3. Add your credentials in OpenBB Workspace
+
+The OpenBB SnapTrade widget is available in the OpenBB Workspace app marketplace.
+
+Click **Add Authentication** and add these two headers, using the values from step 2:
+
+| Header name                       | Value             |
+| --------------------------------- | ----------------- |
+| `x-openbb-snaptrade-client-id`    | Your client ID    |
+| `x-openbb-snaptrade-consumer-key` | Your consumer key |
+
+---
+
+## 4. Connect a brokerage account
+
+Connections are **read-only**.
+
+1. Open the **SnapTrade** app → **Connections** tab. (Or add the **Manage Connections** widget to any dashboard of your own.)
+2. Click **Get Started**. SnapTrade's Connection Portal opens inside the widget.
+3. Pick your brokerage from the list and sign in **on your brokerage's own page**.
+4. When the portal finishes, you're returned to the connections list with the new connection showing. Your accounts now populate every widget.
+
+The same widget is where you manage connections afterward:
+
+- **Connect an Account** — link another brokerage.
+- **Disconnect Account** — remove a connection; its accounts drop out of the dashboards immediately.
+- **Reconnect** — re-authorize a connection your brokerage has expired.

--- a/konfig.yaml
+++ b/konfig.yaml
@@ -74,6 +74,9 @@ portal:
               path: docs/launching-your-application.md
             - id: trade-detection
               path: docs/trade-detection.md
+            - id: openbb-snaptrade-widget
+              path: docs/openbb-snaptrade-widget.md
+              hidden: true
         - label: Billing
           links:
             - id: billing


### PR DESCRIPTION
## Summary

Adds `docs/openbb-snaptrade-widget.md`, a setup guide for the OpenBB Workspace integration: create a Personal SnapTrade account, grab the Personal client ID and consumer key, add them as the `x-openbb-snaptrade-*` auth headers in Workspace, then connect and manage brokerage connections from the widget.

Registered in `konfig.yaml` with `hidden: true`, the same treatment as `oauth-apps`, so the page builds and is reachable at `/docs/openbb-snaptrade-widget` but stays out of the sidebar until we're ready to surface it.

```yaml
- id: openbb-snaptrade-widget
  path: docs/openbb-snaptrade-widget.md
  hidden: true
```

## Notes

- Connections created through the widget are read-only, and the integration accepts Personal keys only.
- Step 3 says the widget is available in the OpenBB Workspace app marketplace — worth confirming that's live before we unhide the page, since the openbb-snaptrade repo currently documents self-hosting.

## Test plan

Docs only. Confirm the page renders in the docs portal preview and does **not** appear in the Guides sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)