### PR TITLE
docs: rename OpenBB SnapTrade widget to OpenBB Snaptrade app

### DIFF
--- a/docs/openbb-snaptrade-widget.md
+++ b/docs/openbb-snaptrade-widget.md
@@ -1,6 +1,6 @@
-# OpenBB SnapTrade Widget
+# OpenBB Snaptrade App
 
-The OpenBB SnapTrade widget connects your own brokerage accounts to OpenBB Workspace through [SnapTrade](https://snaptrade.com), so you can see your live holdings, balances, orders, and activity next to the rest of your research — plus let the Workspace AI agent answer questions about your real portfolio.
+The OpenBB Snaptrade app connects your own brokerage accounts to OpenBB Workspace through [SnapTrade](https://snaptrade.com), so you can see your live holdings, balances, orders, and activity next to the rest of your research — plus let the Workspace AI agent answer questions about your real portfolio.
 
 ---
 
@@ -25,7 +25,7 @@ Treat these keys like a password: they unlock the brokerage accounts you connect
 
 ## 3. Add your credentials in OpenBB Workspace
 
-The OpenBB SnapTrade widget is available in the OpenBB Workspace app marketplace.
+The OpenBB Snaptrade app is available in the OpenBB Workspace app marketplace.
 
 Click **Add Authentication** and add these two headers, using the values from step 2:
 


### PR DESCRIPTION
## What changed

Updates the OpenBB integration guide ([docs/openbb-snaptrade-widget.md](https://github.com/passiv/snaptrade-sdks/blob/master/docs/openbb-snaptrade-widget.md)) to refer to the product as the **"OpenBB Snaptrade app"** instead of the **"OpenBB SnapTrade widget"**. Three occurrences were changed, including the H1 title.

## Why

Matches the current product naming.

## Notes for reviewers

- The file name and doc slug are intentionally **unchanged** (`openbb-snaptrade-widget`), so the published URL `https://docs.snaptrade.com/docs/openbb-snaptrade-widget` stays valid — no redirect needed.
- Other standalone "widget" references (e.g. "Manage Connections widget") were left as-is, since they refer to specific widgets within the app rather than the product name.
- The page remains `hidden: true` in `konfig.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)