### PR TITLE
ci: sync PHP SDK mirrors

### DIFF
--- a/.github/actions/shared/sync-sdk-mirror/action.yml
+++ b/.github/actions/shared/sync-sdk-mirror/action.yml
@@ -1,0 +1,98 @@
+name: Sync SDK mirror
+description: Copies an SDK directory to its publishable mirror and refreshes Packagist
+inputs:
+  source-directory:
+    description: SDK directory in the source repository
+    required: true
+  target-repository:
+    description: GitHub repository in owner/name format
+    required: true
+  target-branch:
+    description: Branch updated in the mirror repository
+    required: false
+    default: master
+  version:
+    description: SDK version used for the immutable Git tag
+    required: true
+  deploy-key:
+    description: Write-enabled deploy key for the mirror repository
+    required: true
+  packagist-repository-url:
+    description: Canonical repository URL registered with Packagist
+    required: true
+  packagist-api-token:
+    description: Packagist API token
+    required: true
+outputs:
+  changed:
+    description: Whether the mirror branch received a new commit
+    value: ${{ steps.sync.outputs.changed }}
+  mirror-sha:
+    description: Commit containing the mirrored SDK
+    value: ${{ steps.sync.outputs.mirror_sha }}
+  tag-created:
+    description: Whether a new version tag was created
+    value: ${{ steps.sync.outputs.tag_created }}
+runs:
+  using: composite
+  steps:
+    - name: Set up mirror deploy key
+      uses: webfactory/ssh-agent@v0.10.0
+      with:
+        ssh-private-key: ${{ inputs.deploy-key }}
+
+    - name: Sync mirror repository
+      id: sync
+      shell: bash
+      env:
+        SOURCE_DIRECTORY: ${{ inputs.source-directory }}
+        SOURCE_REFERENCE: ${{ github.repository }}@${{ github.sha }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        TARGET_REPOSITORY: ${{ inputs.target-repository }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        bash "${{ github.action_path }}/sync-sdk-mirror.sh" \
+          "$SOURCE_DIRECTORY" \
+          "git@github.com:$TARGET_REPOSITORY.git" \
+          "$TARGET_BRANCH" \
+          "$VERSION" \
+          "$SOURCE_REFERENCE"
+
+    - name: Refresh Packagist package
+      shell: bash
+      env:
+        PACKAGIST_API_TOKEN: ${{ inputs.packagist-api-token }}
+        PACKAGIST_REPOSITORY_URL: ${{ inputs.packagist-repository-url }}
+      run: |
+        response_file=$(mktemp)
+        trap 'rm -f "$response_file"' EXIT
+        payload=$(jq -nc \
+          --arg repository "$PACKAGIST_REPOSITORY_URL" \
+          '{repository: $repository}')
+
+        status_code=$(curl \
+          --silent \
+          --show-error \
+          --output "$response_file" \
+          --write-out '%{http_code}' \
+          --retry 3 \
+          --request POST \
+          --header "Authorization: Bearer konfig:$PACKAGIST_API_TOKEN" \
+          --header "Content-Type: application/json" \
+          --header "User-Agent: snaptrade-sdks-php-mirror" \
+          --data "$payload" \
+          https://packagist.org/api/update-package)
+
+        if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
+          echo "::error::Packagist refresh failed with HTTP $status_code."
+          cat "$response_file"
+          exit 1
+        fi
+
+        if [[ "$(jq -r '.status // empty' "$response_file")" != "success" ]]; then
+          echo "::error::Packagist did not accept the package refresh."
+          cat "$response_file"
+          exit 1
+        fi
+
+        echo "Packagist accepted the refresh: $(jq -c '.jobs // []' "$response_file")"

--- a/.github/actions/shared/sync-sdk-mirror/sync-sdk-mirror.sh
+++ b/.github/actions/shared/sync-sdk-mirror/sync-sdk-mirror.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 5 ]]; then
+  echo "Usage: $0 <source-directory> <remote-url> <target-branch> <version> <source-reference>" >&2
+  exit 2
+fi
+
+source_directory=$1
+remote_url=$2
+target_branch=$3
+version=$4
+source_reference=$5
+tag="v$version"
+
+if [[ ! -d "$source_directory" ]]; then
+  echo "Source directory does not exist: $source_directory" >&2
+  exit 1
+fi
+
+if [[ -z "$target_branch" || -z "$version" || -z "$source_reference" ]]; then
+  echo "Target branch, version, and source reference must not be empty." >&2
+  exit 1
+fi
+
+if ! git check-ref-format "refs/tags/$tag"; then
+  echo "Version produces an invalid Git tag: $tag" >&2
+  exit 1
+fi
+
+temporary_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+mirror_directory=$(mktemp -d "$temporary_root/sdk-mirror.XXXXXX")
+trap 'rm -rf "$mirror_directory"' EXIT
+
+git clone \
+  --branch "$target_branch" \
+  --single-branch \
+  "$remote_url" \
+  "$mirror_directory"
+
+git -C "$mirror_directory" config user.name "github-actions[bot]"
+git -C "$mirror_directory" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+rsync \
+  --archive \
+  --delete \
+  --exclude=.git \
+  "$source_directory/" \
+  "$mirror_directory/"
+
+git -C "$mirror_directory" add --all --force
+desired_tree=$(git -C "$mirror_directory" write-tree)
+
+tag_exists=false
+if git ls-remote --exit-code --tags "$remote_url" "refs/tags/$tag" >/dev/null 2>&1; then
+  tag_exists=true
+  git -C "$mirror_directory" fetch \
+    --force \
+    origin \
+    "refs/tags/$tag:refs/tags/$tag"
+  tagged_tree=$(git -C "$mirror_directory" rev-parse "$tag^{tree}")
+
+  if [[ "$tagged_tree" != "$desired_tree" ]]; then
+    echo "Tag $tag already exists with different content; bump the SDK version before mirroring." >&2
+    exit 1
+  fi
+fi
+
+changed=false
+if ! git -C "$mirror_directory" diff --cached --quiet; then
+  changed=true
+  git -C "$mirror_directory" commit -m "Sync from $source_reference"
+fi
+
+tag_created=false
+if [[ "$tag_exists" == false ]]; then
+  tag_created=true
+  git -C "$mirror_directory" tag "$tag"
+fi
+
+if [[ "$changed" == true && "$tag_created" == true ]]; then
+  git -C "$mirror_directory" push \
+    --atomic \
+    origin \
+    "HEAD:refs/heads/$target_branch" \
+    "refs/tags/$tag"
+elif [[ "$changed" == true ]]; then
+  git -C "$mirror_directory" push origin "HEAD:refs/heads/$target_branch"
+elif [[ "$tag_created" == true ]]; then
+  git -C "$mirror_directory" push origin "refs/tags/$tag"
+fi
+
+mirror_sha=$(git -C "$mirror_directory" rev-parse HEAD)
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "changed=$changed" >> "$GITHUB_OUTPUT"
+  echo "mirror_sha=$mirror_sha" >> "$GITHUB_OUTPUT"
+  echo "tag_created=$tag_created" >> "$GITHUB_OUTPUT"
+fi
+
+echo "Mirror commit: $mirror_sha"
+echo "Mirror tree: $desired_tree"
+echo "Version tag: $tag"

--- a/.github/actions/shared/sync-sdk-mirror/sync-sdk-mirror.sh
+++ b/.github/actions/shared/sync-sdk-mirror/sync-sdk-mirror.sh
@@ -2,58 +2,57 @@
 
 set -euo pipefail
 
-if [[ "$#" -ne 5 ]]; then
-  echo "Usage: $0 <source-directory> <remote-url> <target-branch> <version> <source-reference>" >&2
-  exit 2
-fi
+validate_inputs() {
+  if [[ ! -d "$source_directory" ]]; then
+    echo "Source directory does not exist: $source_directory" >&2
+    exit 1
+  fi
 
-source_directory=$1
-remote_url=$2
-target_branch=$3
-version=$4
-source_reference=$5
-tag="v$version"
+  if [[ -z "$target_branch" || -z "$version" || -z "$source_reference" ]]; then
+    echo "Target branch, version, and source reference must not be empty." >&2
+    exit 1
+  fi
 
-if [[ ! -d "$source_directory" ]]; then
-  echo "Source directory does not exist: $source_directory" >&2
-  exit 1
-fi
+  if ! git check-ref-format "refs/tags/$tag"; then
+    echo "Version produces an invalid Git tag: $tag" >&2
+    exit 1
+  fi
+}
 
-if [[ -z "$target_branch" || -z "$version" || -z "$source_reference" ]]; then
-  echo "Target branch, version, and source reference must not be empty." >&2
-  exit 1
-fi
+prepare_mirror_checkout() {
+  local temporary_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+  mirror_directory=$(mktemp -d "$temporary_root/sdk-mirror.XXXXXX")
+  trap 'rm -rf "$mirror_directory"' EXIT
 
-if ! git check-ref-format "refs/tags/$tag"; then
-  echo "Version produces an invalid Git tag: $tag" >&2
-  exit 1
-fi
+  git clone \
+    --branch "$target_branch" \
+    --single-branch \
+    "$remote_url" \
+    "$mirror_directory"
 
-temporary_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
-mirror_directory=$(mktemp -d "$temporary_root/sdk-mirror.XXXXXX")
-trap 'rm -rf "$mirror_directory"' EXIT
+  git -C "$mirror_directory" config user.name "github-actions[bot]"
+  git -C "$mirror_directory" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+}
 
-git clone \
-  --branch "$target_branch" \
-  --single-branch \
-  "$remote_url" \
-  "$mirror_directory"
+stage_authoritative_tree() {
+  rsync \
+    --archive \
+    --delete \
+    --exclude=.git \
+    "$source_directory/" \
+    "$mirror_directory/"
 
-git -C "$mirror_directory" config user.name "github-actions[bot]"
-git -C "$mirror_directory" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git -C "$mirror_directory" add --all --force
+  desired_tree=$(git -C "$mirror_directory" write-tree)
+}
 
-rsync \
-  --archive \
-  --delete \
-  --exclude=.git \
-  "$source_directory/" \
-  "$mirror_directory/"
+enforce_immutable_version_tag() {
+  local tagged_tree
 
-git -C "$mirror_directory" add --all --force
-desired_tree=$(git -C "$mirror_directory" write-tree)
+  if ! git ls-remote --exit-code --tags "$remote_url" "refs/tags/$tag" >/dev/null 2>&1; then
+    return
+  fi
 
-tag_exists=false
-if git ls-remote --exit-code --tags "$remote_url" "refs/tags/$tag" >/dev/null 2>&1; then
   tag_exists=true
   git -C "$mirror_directory" fetch \
     --force \
@@ -61,44 +60,88 @@ if git ls-remote --exit-code --tags "$remote_url" "refs/tags/$tag" >/dev/null 2>
     "refs/tags/$tag:refs/tags/$tag"
   tagged_tree=$(git -C "$mirror_directory" rev-parse "$tag^{tree}")
 
+  # Reject conflicting version content before any remote mutation.
   if [[ "$tagged_tree" != "$desired_tree" ]]; then
     echo "Tag $tag already exists with different content; bump the SDK version before mirroring." >&2
     exit 1
   fi
-fi
+}
 
-changed=false
-if ! git -C "$mirror_directory" diff --cached --quiet; then
+commit_if_changed() {
+  if git -C "$mirror_directory" diff --cached --quiet; then
+    return
+  fi
+
   changed=true
   git -C "$mirror_directory" commit -m "Sync from $source_reference"
-fi
+}
 
-tag_created=false
-if [[ "$tag_exists" == false ]]; then
+create_tag_if_missing() {
+  if [[ "$tag_exists" == true ]]; then
+    return
+  fi
+
   tag_created=true
   git -C "$mirror_directory" tag "$tag"
-fi
+}
 
-if [[ "$changed" == true && "$tag_created" == true ]]; then
-  git -C "$mirror_directory" push \
-    --atomic \
-    origin \
-    "HEAD:refs/heads/$target_branch" \
-    "refs/tags/$tag"
-elif [[ "$changed" == true ]]; then
-  git -C "$mirror_directory" push origin "HEAD:refs/heads/$target_branch"
-elif [[ "$tag_created" == true ]]; then
-  git -C "$mirror_directory" push origin "refs/tags/$tag"
-fi
+push_updates() {
+  # An unchanged branch with an existing tag requires no remote mutation.
+  if [[ "$changed" == true && "$tag_created" == true ]]; then
+    # Keep a new mirror commit and its version tag indivisible.
+    git -C "$mirror_directory" push \
+      --atomic \
+      origin \
+      "HEAD:refs/heads/$target_branch" \
+      "refs/tags/$tag"
+  elif [[ "$changed" == true ]]; then
+    git -C "$mirror_directory" push origin "HEAD:refs/heads/$target_branch"
+  elif [[ "$tag_created" == true ]]; then
+    git -C "$mirror_directory" push origin "refs/tags/$tag"
+  fi
+}
 
-mirror_sha=$(git -C "$mirror_directory" rev-parse HEAD)
+write_results() {
+  local mirror_sha
+  mirror_sha=$(git -C "$mirror_directory" rev-parse HEAD)
 
-if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-  echo "changed=$changed" >> "$GITHUB_OUTPUT"
-  echo "mirror_sha=$mirror_sha" >> "$GITHUB_OUTPUT"
-  echo "tag_created=$tag_created" >> "$GITHUB_OUTPUT"
-fi
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "changed=$changed" >> "$GITHUB_OUTPUT"
+    echo "mirror_sha=$mirror_sha" >> "$GITHUB_OUTPUT"
+    echo "tag_created=$tag_created" >> "$GITHUB_OUTPUT"
+  fi
 
-echo "Mirror commit: $mirror_sha"
-echo "Mirror tree: $desired_tree"
-echo "Version tag: $tag"
+  echo "Mirror commit: $mirror_sha"
+  echo "Mirror tree: $desired_tree"
+  echo "Version tag: $tag"
+}
+
+main() {
+  if [[ "$#" -ne 5 ]]; then
+    echo "Usage: $0 <source-directory> <remote-url> <target-branch> <version> <source-reference>" >&2
+    exit 2
+  fi
+
+  source_directory=$1
+  remote_url=$2
+  target_branch=$3
+  version=$4
+  source_reference=$5
+  tag="v$version"
+  mirror_directory=
+  desired_tree=
+  tag_exists=false
+  changed=false
+  tag_created=false
+
+  validate_inputs
+  prepare_mirror_checkout
+  stage_authoritative_tree
+  enforce_immutable_version_tag
+  commit_if_changed
+  create_tag_if_missing
+  push_updates
+  write_results
+}
+
+main "$@"

--- a/.github/actions/shared/sync-sdk-mirror/test-sync-sdk-mirror.sh
+++ b/.github/actions/shared/sync-sdk-mirror/test-sync-sdk-mirror.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/sync-sdk-mirror-test.XXXXXX")
+trap 'rm -rf "$temporary_root"' EXIT
+
+remote_repository="$temporary_root/remote.git"
+seed_repository="$temporary_root/seed"
+source_directory="$temporary_root/source"
+checkout_directory="$temporary_root/checkout"
+output_file="$temporary_root/github-output"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_equal() {
+  local expected=$1
+  local actual=$2
+  local message=$3
+
+  if [[ "$expected" != "$actual" ]]; then
+    fail "$message (expected '$expected', got '$actual')"
+  fi
+}
+
+remote_head() {
+  git --git-dir="$remote_repository" rev-parse refs/heads/master
+}
+
+remote_tag_tree() {
+  local tag=$1
+  git --git-dir="$remote_repository" rev-parse "$tag^{tree}"
+}
+
+run_sync() {
+  local version=$1
+  : > "$output_file"
+  GITHUB_OUTPUT="$output_file" \
+    RUNNER_TEMP="$temporary_root" \
+    bash "$script_directory/sync-sdk-mirror.sh" \
+      "$source_directory" \
+      "$remote_repository" \
+      master \
+      "$version" \
+      "passiv/snaptrade-sdks@test"
+}
+
+git init --bare "$remote_repository" >/dev/null
+git --git-dir="$remote_repository" symbolic-ref HEAD refs/heads/master
+
+git init "$seed_repository" >/dev/null
+git -C "$seed_repository" config user.name "Test"
+git -C "$seed_repository" config user.email "test@example.com"
+echo "stale" > "$seed_repository/stale.txt"
+git -C "$seed_repository" add stale.txt
+git -C "$seed_repository" commit -m "Seed mirror" >/dev/null
+git -C "$seed_repository" branch -M master
+git -C "$seed_repository" remote add origin "$remote_repository"
+git -C "$seed_repository" push -u origin master >/dev/null
+
+mkdir -p "$source_directory/nested"
+echo "current" > "$source_directory/nested/current.txt"
+echo "hidden" > "$source_directory/.hidden"
+echo "ignored.txt" > "$source_directory/.gitignore"
+echo "committed source content" > "$source_directory/ignored.txt"
+echo "#!/usr/bin/env bash" > "$source_directory/executable.sh"
+chmod +x "$source_directory/executable.sh"
+
+run_sync 1.2.3
+first_head=$(remote_head)
+assert_equal "$first_head" "$(git --git-dir="$remote_repository" rev-parse refs/tags/v1.2.3)" "Initial tag must point to the mirrored commit"
+
+git clone "$remote_repository" "$checkout_directory" >/dev/null
+diff --recursive --exclude=.git "$source_directory" "$checkout_directory" >/dev/null ||
+  fail "Initial mirror content must match the source directory"
+[[ -x "$checkout_directory/executable.sh" ]] ||
+  fail "Executable file mode must be preserved"
+[[ ! -e "$checkout_directory/stale.txt" ]] ||
+  fail "Files absent from the source must be deleted"
+
+run_sync 1.2.3
+assert_equal "$first_head" "$(remote_head)" "Matching rerun must not create a commit"
+grep -qx "changed=false" "$output_file" ||
+  fail "Matching rerun must report changed=false"
+grep -qx "tag_created=false" "$output_file" ||
+  fail "Matching rerun must report tag_created=false"
+
+run_sync 1.2.4
+assert_equal "$first_head" "$(remote_head)" "Adding a tag must not create a commit"
+assert_equal "$(remote_tag_tree v1.2.3)" "$(remote_tag_tree v1.2.4)" "New tag must use the current source tree"
+
+rm "$source_directory/nested/current.txt"
+echo "updated" > "$source_directory/updated.txt"
+run_sync 1.2.5
+second_head=$(remote_head)
+[[ "$second_head" != "$first_head" ]] ||
+  fail "Changed source content must create a mirror commit"
+
+git --git-dir="$remote_repository" tag v9.9.9 refs/heads/master
+echo "conflicting" > "$source_directory/conflicting.txt"
+head_before_conflict=$(remote_head)
+if run_sync 9.9.9; then
+  fail "A tag containing different content must be rejected"
+fi
+assert_equal "$head_before_conflict" "$(remote_head)" "Tag conflict must not mutate the mirror branch"
+
+cat > "$remote_repository/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+exit 1
+HOOK
+chmod +x "$remote_repository/hooks/pre-receive"
+head_before_rejection=$(remote_head)
+if run_sync 10.0.0; then
+  fail "A rejected atomic push must fail"
+fi
+assert_equal "$head_before_rejection" "$(remote_head)" "Rejected push must not mutate the mirror branch"
+if git --git-dir="$remote_repository" rev-parse --verify refs/tags/v10.0.0 >/dev/null 2>&1; then
+  fail "Rejected atomic push must not create its tag"
+fi
+
+echo "All sync-sdk-mirror tests passed."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,3 +190,17 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: konfig publish --generator ${{ matrix.language }} --skipTests --tolerateRepublish --skipRemoteCheck --ci
+
+  sync-php-mirrors:
+    name: Sync PHP mirrors
+    needs: detect-changesets
+    if: needs.detect-changesets.outputs.has_changesets == 'false'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/sync-php-mirrors.yaml
+    secrets:
+      TEST_ENV: ${{ secrets.TEST_ENV }}
+      PHP_MIRROR_DEPLOY_KEY: ${{ secrets.PHP_MIRROR_DEPLOY_KEY }}
+      PHP7_MIRROR_DEPLOY_KEY: ${{ secrets.PHP7_MIRROR_DEPLOY_KEY }}
+      PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}

--- a/.github/workflows/sync-php-mirrors.yaml
+++ b/.github/workflows/sync-php-mirrors.yaml
@@ -1,0 +1,151 @@
+name: Sync PHP mirrors
+
+on:
+  workflow_call:
+    secrets:
+      TEST_ENV:
+        required: true
+      PHP_MIRROR_DEPLOY_KEY:
+        required: true
+      PHP7_MIRROR_DEPLOY_KEY:
+        required: true
+      PACKAGIST_API_TOKEN:
+        required: true
+  workflow_dispatch:
+
+concurrency:
+  group: sync-php-mirrors
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Resolve PHP versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      php_version: ${{ steps.php-version.outputs.result }}
+      php7_version: ${{ steps.php7-version.outputs.result }}
+    steps:
+      - name: Require the default branch
+        env:
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          if [[ "$SOURCE_REF" != "refs/heads/master" ]]; then
+            echo "::error::PHP mirrors can only be synchronized from master."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Resolve PHP version
+        id: php-version
+        uses: mikefarah/yq@v4.35.2
+        with:
+          cmd: yq -r '.generators.php.version' konfig.yaml
+
+      - name: Resolve PHP7 version
+        id: php7-version
+        uses: mikefarah/yq@v4.35.2
+        with:
+          cmd: yq -r '.additionalGenerators.php7.version' konfig.yaml
+
+      - name: Validate PHP versions
+        env:
+          PHP_VERSION: ${{ steps.php-version.outputs.result }}
+          PHP7_VERSION: ${{ steps.php7-version.outputs.result }}
+        run: |
+          for version in "$PHP_VERSION" "$PHP7_VERSION"; do
+            if [[ -z "$version" || "$version" == "null" ]]; then
+              echo "::error::Both PHP generators must have a configured version."
+              exit 1
+            fi
+
+            if ! git check-ref-format "refs/tags/v$version"; then
+              echo "::error::Invalid PHP SDK version tag: v$version"
+              exit 1
+            fi
+          done
+
+  test:
+    name: Test ${{ matrix.generator }} SDK
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      matrix:
+        generator:
+          - php
+          - php7
+    container:
+      image: konfigdev/test-and-publish:latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Install CLI
+        uses: ./.github/actions/shared/install-cli
+
+      - name: Set up test environment
+        uses: ./.github/actions/shared/inject-testing-env-vars
+        with:
+          test_env: ${{ secrets.TEST_ENV }}
+
+      - name: Test SDK
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_on: error
+          command: konfig test --filter ${{ matrix.generator }}
+
+  sync-php:
+    name: Sync PHP mirror
+    needs:
+      - prepare
+      - test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Sync PHP mirror
+        uses: ./.github/actions/shared/sync-sdk-mirror
+        with:
+          source-directory: sdks/php
+          target-repository: passiv/snaptrade-php-sdk
+          version: ${{ needs.prepare.outputs.php_version }}
+          deploy-key: ${{ secrets.PHP_MIRROR_DEPLOY_KEY }}
+          packagist-repository-url: https://github.com/passiv/snaptrade-php-sdk
+          packagist-api-token: ${{ secrets.PACKAGIST_API_TOKEN }}
+
+  sync-php7:
+    name: Sync PHP7 mirror
+    needs:
+      - prepare
+      - test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Sync PHP7 mirror
+        uses: ./.github/actions/shared/sync-sdk-mirror
+        with:
+          source-directory: sdks/php7
+          target-repository: passiv/snaptrade-php-7-sdk
+          version: ${{ needs.prepare.outputs.php7_version }}
+          deploy-key: ${{ secrets.PHP7_MIRROR_DEPLOY_KEY }}
+          packagist-repository-url: https://github.com/passiv/snaptrade-php-7-sdk
+          packagist-api-token: ${{ secrets.PACKAGIST_API_TOKEN }}


### PR DESCRIPTION
## Summary

- add a reusable mirror action that copies an authoritative SDK directory into its publishable repository
- add a reusable and manually dispatchable workflow for the PHP and PHP7 mirrors
- test both SDKs before synchronizing their mirror branches and refreshing Packagist
- invoke the mirror workflow from releases while keeping PHP generators out of `konfig publish`

## Why

PHP SDKs now live as ordinary directories in `snaptrade-sdks`, while Packagist still needs dedicated repositories. This adds an explicit, independently testable propagation mechanism from the authoritative directories to those publishable mirrors.

## Behavior

- pushes to mirror `master` are non-force
- branch and new version tag updates are atomic
- existing version tags are immutable and conflicting content fails before any remote mutation
- unchanged reruns are idempotent
- the workflow requires separate deploy keys for PHP and PHP7, and reuses the existing Packagist and test-environment secrets

## Validation

- mirror integration test covering initial sync, deletion and mode propagation, ignored source files, unchanged reruns, tag-only updates, tag conflicts, and rejected atomic pushes
- Bash syntax checks
- YAML parsing
- `actionlint`
- `git diff --check`

No live mirror repository was modified during validation.