### PR TITLE
refactor(ci): simplify PHP mirror sync

### DIFF
--- a/.github/actions/shared/sync-sdk-mirror/action.yml
+++ b/.github/actions/shared/sync-sdk-mirror/action.yml
@@ -28,7 +28,7 @@ outputs:
     description: Whether the mirror branch received a new commit
     value: ${{ steps.sync.outputs.changed }}
   mirror-sha:
-    description: Commit containing the mirrored SDK
+    description: Current mirror branch commit after synchronization
     value: ${{ steps.sync.outputs.mirror_sha }}
   tag-created:
     description: Whether a new version tag was created
@@ -36,24 +36,39 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up mirror deploy key
-      uses: webfactory/ssh-agent@v0.10.0
+    - name: Check out mirror repository
+      uses: actions/checkout@v6
       with:
-        ssh-private-key: ${{ inputs.deploy-key }}
+        repository: ${{ inputs.target-repository }}
+        ref: ${{ inputs.target-branch }}
+        ssh-key: ${{ inputs.deploy-key }}
+        path: .sdk-mirror
+        fetch-depth: 0
 
-    - name: Sync mirror repository
+    - name: Copy SDK to mirror
+      shell: bash
+      env:
+        MIRROR_DIRECTORY: ${{ github.workspace }}/.sdk-mirror
+        SOURCE_DIRECTORY: ${{ github.workspace }}/${{ inputs.source-directory }}
+      run: |
+        rsync \
+          --archive \
+          --delete \
+          --exclude=.git \
+          "$SOURCE_DIRECTORY/" \
+          "$MIRROR_DIRECTORY/"
+
+    - name: Enforce mirror publishing rules
       id: sync
       shell: bash
       env:
-        SOURCE_DIRECTORY: ${{ inputs.source-directory }}
+        MIRROR_DIRECTORY: ${{ github.workspace }}/.sdk-mirror
         SOURCE_REFERENCE: ${{ github.repository }}@${{ github.sha }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
-        TARGET_REPOSITORY: ${{ inputs.target-repository }}
         VERSION: ${{ inputs.version }}
       run: |
         bash "${{ github.action_path }}/sync-sdk-mirror.sh" \
-          "$SOURCE_DIRECTORY" \
-          "git@github.com:$TARGET_REPOSITORY.git" \
+          "$MIRROR_DIRECTORY" \
           "$TARGET_BRANCH" \
           "$VERSION" \
           "$SOURCE_REFERENCE"

--- a/.github/actions/shared/sync-sdk-mirror/sync-sdk-mirror.sh
+++ b/.github/actions/shared/sync-sdk-mirror/sync-sdk-mirror.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 validate_inputs() {
-  if [[ ! -d "$source_directory" ]]; then
-    echo "Source directory does not exist: $source_directory" >&2
+  if ! git -C "$mirror_directory" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Mirror directory is not a Git worktree: $mirror_directory" >&2
     exit 1
   fi
 
@@ -19,29 +19,7 @@ validate_inputs() {
   fi
 }
 
-prepare_mirror_checkout() {
-  local temporary_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
-  mirror_directory=$(mktemp -d "$temporary_root/sdk-mirror.XXXXXX")
-  trap 'rm -rf "$mirror_directory"' EXIT
-
-  git clone \
-    --branch "$target_branch" \
-    --single-branch \
-    "$remote_url" \
-    "$mirror_directory"
-
-  git -C "$mirror_directory" config user.name "github-actions[bot]"
-  git -C "$mirror_directory" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-}
-
-stage_authoritative_tree() {
-  rsync \
-    --archive \
-    --delete \
-    --exclude=.git \
-    "$source_directory/" \
-    "$mirror_directory/"
-
+stage_mirror_tree() {
   git -C "$mirror_directory" add --all --force
   desired_tree=$(git -C "$mirror_directory" write-tree)
 }
@@ -49,21 +27,16 @@ stage_authoritative_tree() {
 enforce_immutable_version_tag() {
   local tagged_tree
 
-  if ! git ls-remote --exit-code --tags "$remote_url" "refs/tags/$tag" >/dev/null 2>&1; then
+  if ! git -C "$mirror_directory" show-ref --verify --quiet "refs/tags/$tag"; then
     return
   fi
 
   tag_exists=true
-  git -C "$mirror_directory" fetch \
-    --force \
-    origin \
-    "refs/tags/$tag:refs/tags/$tag"
   tagged_tree=$(git -C "$mirror_directory" rev-parse "$tag^{tree}")
 
-  # Reject conflicting version content before any remote mutation.
   if [[ "$tagged_tree" != "$desired_tree" ]]; then
-    echo "Tag $tag already exists with different content; bump the SDK version before mirroring." >&2
-    exit 1
+    tag_conflicts=true
+    echo "::warning::Tag $tag already exists with different content; mirror update skipped."
   fi
 }
 
@@ -112,32 +85,38 @@ write_results() {
   fi
 
   echo "Mirror commit: $mirror_sha"
-  echo "Mirror tree: $desired_tree"
+  echo "Desired source tree: $desired_tree"
   echo "Version tag: $tag"
 }
 
 main() {
-  if [[ "$#" -ne 5 ]]; then
-    echo "Usage: $0 <source-directory> <remote-url> <target-branch> <version> <source-reference>" >&2
+  if [[ "$#" -ne 4 ]]; then
+    echo "Usage: $0 <mirror-directory> <target-branch> <version> <source-reference>" >&2
     exit 2
   fi
 
-  source_directory=$1
-  remote_url=$2
-  target_branch=$3
-  version=$4
-  source_reference=$5
+  mirror_directory=$1
+  target_branch=$2
+  version=$3
+  source_reference=$4
   tag="v$version"
-  mirror_directory=
   desired_tree=
   tag_exists=false
+  tag_conflicts=false
   changed=false
   tag_created=false
 
   validate_inputs
-  prepare_mirror_checkout
-  stage_authoritative_tree
+  git -C "$mirror_directory" config user.name "github-actions[bot]"
+  git -C "$mirror_directory" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  stage_mirror_tree
   enforce_immutable_version_tag
+
+  if [[ "$tag_conflicts" == true ]]; then
+    write_results
+    return
+  fi
+
   commit_if_changed
   create_tag_if_missing
   push_updates

--- a/.github/actions/shared/sync-sdk-mirror/test-sync-sdk-mirror.sh
+++ b/.github/actions/shared/sync-sdk-mirror/test-sync-sdk-mirror.sh
@@ -11,6 +11,7 @@ seed_repository="$temporary_root/seed"
 source_directory="$temporary_root/source"
 checkout_directory="$temporary_root/checkout"
 output_file="$temporary_root/github-output"
+log_file="$temporary_root/sync-log"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -38,15 +39,27 @@ remote_tag_tree() {
 
 run_sync() {
   local version=$1
+  local mirror_directory
+
+  mirror_directory=$(mktemp -d "$temporary_root/mirror.XXXXXX")
+  git clone --branch master "$remote_repository" "$mirror_directory" >/dev/null
+
+  rsync \
+    --archive \
+    --delete \
+    --exclude=.git \
+    "$source_directory/" \
+    "$mirror_directory/"
+
   : > "$output_file"
+  : > "$log_file"
   GITHUB_OUTPUT="$output_file" \
-    RUNNER_TEMP="$temporary_root" \
     bash "$script_directory/sync-sdk-mirror.sh" \
-      "$source_directory" \
-      "$remote_repository" \
+      "$mirror_directory" \
       master \
       "$version" \
-      "passiv/snaptrade-sdks@test"
+      "passiv/snaptrade-sdks@test" 2>&1 |
+    tee "$log_file"
 }
 
 git init --bare "$remote_repository" >/dev/null
@@ -101,12 +114,20 @@ second_head=$(remote_head)
   fail "Changed source content must create a mirror commit"
 
 git --git-dir="$remote_repository" tag v9.9.9 refs/heads/master
+conflicting_tag=$(git --git-dir="$remote_repository" rev-parse refs/tags/v9.9.9)
 echo "conflicting" > "$source_directory/conflicting.txt"
 head_before_conflict=$(remote_head)
-if run_sync 9.9.9; then
-  fail "A tag containing different content must be rejected"
-fi
+run_sync 9.9.9
 assert_equal "$head_before_conflict" "$(remote_head)" "Tag conflict must not mutate the mirror branch"
+assert_equal "$conflicting_tag" "$(git --git-dir="$remote_repository" rev-parse refs/tags/v9.9.9)" "Tag conflict must not mutate the existing tag"
+grep -Fqx "::warning::Tag v9.9.9 already exists with different content; mirror update skipped." "$log_file" ||
+  fail "Tag conflict must emit a warning"
+grep -qx "changed=false" "$output_file" ||
+  fail "Tag conflict must report changed=false"
+grep -qx "tag_created=false" "$output_file" ||
+  fail "Tag conflict must report tag_created=false"
+grep -qx "mirror_sha=$head_before_conflict" "$output_file" ||
+  fail "Tag conflict must report the unchanged mirror commit"
 
 cat > "$remote_repository/hooks/pre-receive" <<'HOOK'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- use `actions/checkout` for mirror repository checkout and deploy-key authentication
- keep exact SDK copying as a direct `rsync` step
- reduce the custom script to Git publishing enforcement
- tolerate an existing version tag with different content by warning and skipping the mirror update

## Why

The initial mirror implementation combined standard checkout and copy mechanics with the custom safety rules. Separating those responsibilities makes the workflow easier to read and keeps custom code focused on the behavior that existing actions do not provide.

The conflict behavior now also matches the other SDK publishers' tolerate-republish semantics: immutable existing tags remain untouched, but an attempted republish does not fail CI.

## Behavior preserved

- exact directory synchronization, including deletions and executable modes
- immutable version tags
- non-force branch pushes
- atomic branch and new-tag updates
- unchanged-run idempotency
- Packagist refresh after successful enforcement

## Validation

- Bash syntax checks
- mirror integration suite covering initial sync, deletions, modes, ignored source files, unchanged reruns, tag-only updates, tolerated tag conflicts, and rejected atomic pushes
- YAML parsing
- `actionlint`
- `git diff --check`