### PR TITLE
fix(ci): allow CLI install in regeneration merge

### DIFF
--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -249,6 +249,7 @@ jobs:
       deployment: false
     permissions:
       contents: write
+      packages: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- grant the regeneration merge job `packages: read`
- allow the job to install the private `@passiv/konfig-cli` package before running `konfig pr-merge`

## Root cause

The merge job defines explicit permissions but omitted package read access. After all generated SDK tests passed, the CLI installation failed with HTTP 403 because the job could not read the organization package.

Failing run: https://github.com/passiv/snaptrade-sdks/actions/runs/30557474972

## Validation

- `actionlint .github/workflows/regenerate-sdks.yaml`
- YAML parsing
- `git diff --check`