### PR TITLE
ci: add manual Bump or Release trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
-name: Release
+name: Bump or Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/slack-ci-failure-alert.yaml
+++ b/.github/workflows/slack-ci-failure-alert.yaml
@@ -3,7 +3,7 @@ name: Slack CI failure alert
 on:
   workflow_run:
     workflows:
-      - Release
+      - Bump or Release
       - Regenerate SDKs
       - OpenAPI lint
       - Revalidate portal


### PR DESCRIPTION
## Summary

- add a manual dispatch trigger to the existing release workflow
- rename the workflow from `Release` to `Bump or Release` to describe its two phases
- update Slack failure monitoring to match the new workflow display name

## Impact

Maintainers can manually run the workflow against `master` to process pending changesets or publish already-bumped SDKs. The workflow stays at `.github/workflows/release.yaml`, preserving its GitHub workflow identity and run history.

## Validation

- `actionlint .github/workflows/release.yaml .github/workflows/slack-ci-failure-alert.yaml`
- YAML parsing
- `git diff --check`