### PR TITLE
fix(ci): remap PHP mirror deploy keys

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -202,6 +202,7 @@ jobs:
     uses: ./.github/workflows/sync-php-mirrors.yaml
     secrets:
       TEST_ENV: ${{ secrets.TEST_ENV }}
-      PHP_MIRROR_DEPLOY_KEY: ${{ secrets.PHP_MIRROR_DEPLOY_KEY }}
-      PHP7_MIRROR_DEPLOY_KEY: ${{ secrets.PHP7_MIRROR_DEPLOY_KEY }}
+      # These historical secret names no longer imply that the PHP SDKs are submodules.
+      PHP_MIRROR_DEPLOY_KEY: ${{ secrets.SUBMODULE_DEPLOY_KEY_PHP }}
+      PHP7_MIRROR_DEPLOY_KEY: ${{ secrets.SUBMODULE_DEPLOY_KEY_PHP7 }}
       PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}


### PR DESCRIPTION
## Summary

- map the PHP mirror workflow inputs to the existing deploy-key secrets
- document that the historical `SUBMODULE_DEPLOY_KEY_*` names no longer imply a submodule layout

## Root cause

The migrated workflow referenced new `PHP_MIRROR_DEPLOY_KEY` and `PHP7_MIRROR_DEPLOY_KEY` repository secrets, but the repository still stores the write-enabled keys as `SUBMODULE_DEPLOY_KEY_PHP` and `SUBMODULE_DEPLOY_KEY_PHP7`. Empty SSH-key inputs made checkout fall back to `GITHUB_TOKEN`, which can clone the public mirror repositories but cannot push to them.

Failed run: https://github.com/passiv/snaptrade-sdks/actions/runs/30572141488

## Impact

PHP and PHP7 mirror jobs will authenticate with their existing write-enabled deploy keys. No secret rotation or repository-layout change is required.

## Validation

- `actionlint .github/workflows/release.yaml`
- YAML parsing
- `git diff --check`