### PR TITLE
ci: enable C# trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,9 +123,8 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        # C# remains disabled while NuGet trusted publishing is unresolved.
         # PHP SDKs are published from their mirrored repositories.
-        language: [typescript, python, go, ruby, java]
+        language: [typescript, python, go, ruby, java, csharp]
     container:
       image: konfigdev/test-and-publish:latest
     env:
@@ -184,8 +183,17 @@ jobs:
           central_token_username: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           central_token_password: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
 
+      - name: Log in to NuGet
+        if: matrix.language == 'csharp'
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: snaptrade
+
       - name: Publish SDK
         uses: nick-fields/retry@v4
+        env:
+          NUGET_TRUSTED_PUBLISHING_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         with:
           timeout_minutes: 15
           max_attempts: 3


### PR DESCRIPTION
## Summary

- restore C# to the SDK publishing matrix
- exchange the GitHub OIDC token for a short-lived NuGet API key with `NuGet/login@v1`
- pass the temporary credential to the CLI through `NUGET_TRUSTED_PUBLISHING_API_KEY`

## Impact

C# releases can publish `SnapTrade.Net` without a long-lived NuGet API key. The existing publish job already grants `id-token: write`, and the temporary credential is requested immediately before publishing.

## Required nuget.org policy

Configure the trusted-publishing policy before merging:

- Policy owner: `snaptrade`
- Repository owner: `passiv`
- Repository: `snaptrade-sdks`
- Workflow file: `release.yaml`
- Environment: leave blank

## Validation

- `actionlint .github/workflows/release.yaml`
- YAML parsing
- `git diff --check`