### PR TITLE
ci: skip portal revalidation for workflow-only changes

### DIFF
--- a/.github/workflows/revalidate-portal.yaml
+++ b/.github/workflows/revalidate-portal.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - .github/**
 
 jobs:
   revalidate:


### PR DESCRIPTION
## Summary

- skip portal revalidation when a push changes only files under `.github/`
- preserve revalidation for every push containing at least one non-workflow change

## Impact

CI-only changes no longer install the CLI and revalidate the documentation portal unnecessarily. Mixed commits that also modify API, documentation, configuration, SDK, or other repository content continue to trigger the workflow.

## Validation

- `actionlint .github/workflows/revalidate-portal.yaml`
- YAML parsing
- `git diff --check`