### PR TITLE
fix(ci): pass trusted NuGet key to publisher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Publish SDK
         uses: nick-fields/retry@v4
         env:
-          NUGET_TRUSTED_PUBLISHING_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         with:
           timeout_minutes: 15
           max_attempts: 3


### PR DESCRIPTION
## Summary

- expose the short-lived key returned by `NuGet/login` under the `NUGET_API_KEY` name consumed by `konfig publish`

## Root cause

Trusted publishing successfully exchanged the GitHub OIDC token for a temporary NuGet API key, but the workflow passed it as `NUGET_TRUSTED_PUBLISHING_API_KEY`. The publisher reads `NUGET_API_KEY`, so it reported that the credential was missing.

## Validation

- `actionlint .github/workflows/release.yaml`
- YAML parsing
- `git diff --check`