### PR TITLE
refactor(ci): remove duplicate PHP mirror tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,7 +209,6 @@ jobs:
       packages: read
     uses: ./.github/workflows/sync-php-mirrors.yaml
     secrets:
-      TEST_ENV: ${{ secrets.TEST_ENV }}
       # These historical secret names no longer imply that the PHP SDKs are submodules.
       PHP_MIRROR_DEPLOY_KEY: ${{ secrets.SUBMODULE_DEPLOY_KEY_PHP }}
       PHP7_MIRROR_DEPLOY_KEY: ${{ secrets.SUBMODULE_DEPLOY_KEY_PHP7 }}

--- a/.github/workflows/sync-php-mirrors.yaml
+++ b/.github/workflows/sync-php-mirrors.yaml
@@ -3,8 +3,6 @@ name: Sync PHP mirrors
 on:
   workflow_call:
     secrets:
-      TEST_ENV:
-        required: true
       PHP_MIRROR_DEPLOY_KEY:
         required: true
       PHP7_MIRROR_DEPLOY_KEY:
@@ -69,46 +67,9 @@ jobs:
             fi
           done
 
-  test:
-    name: Test ${{ matrix.generator }} SDK
-    needs: prepare
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    strategy:
-      matrix:
-        generator:
-          - php
-          - php7
-    container:
-      image: konfigdev/test-and-publish:latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Install CLI
-        uses: ./.github/actions/shared/install-cli
-
-      - name: Set up test environment
-        uses: ./.github/actions/shared/inject-testing-env-vars
-        with:
-          test_env: ${{ secrets.TEST_ENV }}
-
-      - name: Test SDK
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_on: error
-          command: konfig test --filter ${{ matrix.generator }}
-
   sync-php:
     name: Sync PHP mirror
-    needs:
-      - prepare
-      - test
+    needs: prepare
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -129,9 +90,7 @@ jobs:
 
   sync-php7:
     name: Sync PHP7 mirror
-    needs:
-      - prepare
-      - test
+    needs: prepare
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- remove the second PHP/PHP7 test matrix from the mirror workflow
- let both mirror jobs proceed after version validation
- remove the now-unused `TEST_ENV` secret plumbing from the reusable workflow call

## Rationale

SDK regeneration already tests PHP and PHP7 before the generated changes can merge. The mirror workflow copies those tested SDK directories without regenerating them, so repeating both suites delayed mirroring without validating a different artifact.

The mirror workflow still validates configured versions, enforces immutable tags, pushes with deploy keys, and refreshes Packagist.

## Validation

- `actionlint .github/workflows/release.yaml .github/workflows/sync-php-mirrors.yaml`
- YAML parsing
- `git diff --check`