### PR TITLE
test: stop using deprecated endpoints

### DIFF
--- a/sdks/csharp/src/SnapTrade.Net.Test/Api/CryptoTradingExamplesTests.cs
+++ b/sdks/csharp/src/SnapTrade.Net.Test/Api/CryptoTradingExamplesTests.cs
@@ -77,7 +77,7 @@ namespace SnapTrade.Net.Test.Api
             Console.WriteLine("placeOrderResult: {0}", placeOrderResult);
 
             // Cancel the order
-            var tradingCancelUserAccountOrderRequest = new AccountInformationGetUserAccountOrderDetailRequest(
+            var tradingCancelOrderRequest = new AccountInformationGetUserAccountOrderDetailRequest(
                 placeOrderResult.BrokerageOrderId
             );
         
@@ -85,7 +85,7 @@ namespace SnapTrade.Net.Test.Api
                 testUserId,
                 testUserSecret,
                 accountId: accountId,
-                accountInformationGetUserAccountOrderDetailRequest: tradingCancelUserAccountOrderRequest
+                accountInformationGetUserAccountOrderDetailRequest: tradingCancelOrderRequest
             );
           
             Console.WriteLine("cancelOrderResult: {0}", cancelOrderResult);

--- a/sdks/csharp/src/SnapTrade.Net.Test/Api/TradingApiTests.cs
+++ b/sdks/csharp/src/SnapTrade.Net.Test/Api/TradingApiTests.cs
@@ -47,29 +47,29 @@ namespace SnapTrade.Net.Test.Api
         }
 
         /// <summary>
-        /// Test CancelUserAccountOrder
+        /// Test CancelOrder
         /// </summary>
         [Fact]
-        public void CancelUserAccountOrderTest()
+        public void CancelOrderTest()
         {
             var userId = "userId_example";
             var userSecret = "userSecret_example";
             var accountId = "917c8734-8470-4a3e-a18f-57c3f2ee6631";
             var brokerageOrderId = "66a033fa-da74-4fcf-b527-feefdec9257e"; // Order ID returned by brokerage. This is the unique identifier for the order in the brokerage system.
             
-            var tradingCancelUserAccountOrderRequest = new AccountInformationGetUserAccountOrderDetailRequest(
+            var tradingCancelOrderRequest = new AccountInformationGetUserAccountOrderDetailRequest(
                 brokerageOrderId
             );
             
             try
             {
                 // Cancel order
-                AccountOrderRecord result = client.Trading.CancelUserAccountOrder(userId, userSecret, accountId, tradingCancelUserAccountOrderRequest);
+                CancelOrderResponse result = client.Trading.CancelOrder(userId, userSecret, accountId, tradingCancelOrderRequest);
                 Console.WriteLine(result);
             }
             catch (ApiException e)
             {
-                Console.WriteLine("Exception when calling TradingApi.CancelUserAccountOrder: " + e.Message);
+                Console.WriteLine("Exception when calling TradingApi.CancelOrder: " + e.Message);
                 Console.WriteLine("Status Code: "+ e.ErrorCode);
                 Console.WriteLine(e.StackTrace);
             }

--- a/sdks/csharp/src/SnapTrade.Net.Test/GettingStartedTests.cs
+++ b/sdks/csharp/src/SnapTrade.Net.Test/GettingStartedTests.cs
@@ -37,11 +37,7 @@ namespace SnapTrade.Net.Test.Api
         private AuthenticationApi authenticationApi;
         private AccountInformationApi accountInformationApi;
 
-        private TransactionsAndReportingApi transactionsAndReportingApi;
-
         private ReferenceDataApi referenceDataApi;
-
-        private OptionsApi optionsApi;
 
         private string testUserId;
 
@@ -63,9 +59,7 @@ namespace SnapTrade.Net.Test.Api
             apiStatusApi = new APIStatusApi(configuration);
             authenticationApi = new AuthenticationApi(configuration);
             accountInformationApi = new AccountInformationApi(configuration);
-            transactionsAndReportingApi = new TransactionsAndReportingApi(configuration);
             referenceDataApi = new ReferenceDataApi(configuration);
-            optionsApi = new OptionsApi(configuration);
         }
 
         public void Dispose()
@@ -97,8 +91,8 @@ namespace SnapTrade.Net.Test.Api
             Console.WriteLine(string.Format("userID: {0}, userSecret: {1}", userIDandSecret.UserId, userIDandSecret.UserSecret));
             var redirectUri = authenticationApi.LoginSnapTradeUser(userIDandSecret.UserId, userIDandSecret.UserSecret).GetLoginRedirectURI().RedirectURI;
             Console.WriteLine(redirectUri);
-            var holdings = accountInformationApi.GetAllUserHoldings(userIDandSecret.UserId, userIDandSecret.UserSecret);
-            Console.WriteLine(holdings);
+            var accounts = accountInformationApi.ListUserAccounts(userIDandSecret.UserId, userIDandSecret.UserSecret);
+            Console.WriteLine(accounts);
             var deleteResponse = authenticationApi.DeleteSnapTradeUser(userIDandSecret.UserId);
             Console.WriteLine(deleteResponse);
         }
@@ -116,8 +110,8 @@ namespace SnapTrade.Net.Test.Api
             Console.WriteLine(string.Format("userID: {0}, userSecret: {1}", userIDandSecret.UserId, userIDandSecret.UserSecret));
             var redirectUri = snaptrade.Authentication.LoginSnapTradeUser(userIDandSecret.UserId, userIDandSecret.UserSecret).GetLoginRedirectURI().RedirectURI;
             Console.WriteLine(redirectUri);
-            var holdings = snaptrade.AccountInformation.GetAllUserHoldings(userIDandSecret.UserId, userIDandSecret.UserSecret);
-            Console.WriteLine(holdings);
+            var accounts = snaptrade.AccountInformation.ListUserAccounts(userIDandSecret.UserId, userIDandSecret.UserSecret);
+            Console.WriteLine(accounts);
             var deleteResponse = snaptrade.Authentication.DeleteSnapTradeUser(userIDandSecret.UserId);
             Console.WriteLine(deleteResponse);
         }
@@ -133,8 +127,8 @@ namespace SnapTrade.Net.Test.Api
             Console.WriteLine(string.Format("userID: {0}, userSecret: {1}", userIDandSecret.UserId, userIDandSecret.UserSecret));
             var redirectUri = authenticationApi.LoginSnapTradeUser(userIDandSecret.UserId, userIDandSecret.UserSecret).GetLoginRedirectURI().RedirectURI;
             Console.WriteLine(redirectUri);
-            var holdings = accountInformationApi.GetAllUserHoldings(userIDandSecret.UserId, userIDandSecret.UserSecret);
-            Console.WriteLine(holdings);
+            var accounts = accountInformationApi.ListUserAccounts(userIDandSecret.UserId, userIDandSecret.UserSecret);
+            Console.WriteLine(accounts);
             var deleteResponse = authenticationApi.DeleteSnapTradeUser(userIDandSecret.UserId);
             Console.WriteLine(deleteResponse);
         }
@@ -149,29 +143,29 @@ namespace SnapTrade.Net.Test.Api
         }
 
         [Fact]
-        public void GetAllUserHoldings()
+        public void ListUserAccounts()
         {
-            // List all accounts for the user, plus balances and positions for each account.
-            List<AccountHoldings> result = accountInformationApi.GetAllUserHoldings(this.testUserId, this.testUserSecret);
+            var result = accountInformationApi.ListUserAccounts(this.testUserId, this.testUserSecret);
             Console.WriteLine(result);
         }
 
         [Fact]
-        async public void GetUserHoldings()
+        async public void GetAllAccountPositions()
         {
             var accounts = await accountInformationApi.ListUserAccountsAsync(this.testUserId, this.testUserSecret);
             Console.WriteLine(accounts);
-            var response = await accountInformationApi.GetUserHoldingsAsync(accounts[0].Id, this.testUserId, this.testUserSecret);
+            var response = await accountInformationApi.GetAllAccountPositionsAsync(this.testUserId, this.testUserSecret, accounts[0].Id);
             Console.WriteLine(response);
         }
 
 
         [Fact]
-        async public void GetActivitiesAsync()
+        async public void GetAccountActivitiesAsync()
         {
+            var accounts = await accountInformationApi.ListUserAccountsAsync(this.testUserId, this.testUserSecret);
             var from = DateTime.Now.AddYears(-1);
             var to = DateTime.Now;
-            var activities = await transactionsAndReportingApi.GetActivitiesAsync(this.testUserId, this.testUserSecret, from, to);
+            var activities = await accountInformationApi.GetAccountActivitiesAsync(accounts[0].Id, this.testUserId, this.testUserSecret, from, to);
             Console.WriteLine(activities);
         }
 

--- a/sdks/go/test/getting_started_test.go
+++ b/sdks/go/test/getting_started_test.go
@@ -71,10 +71,10 @@ func Test_snaptrade_GettingStarted(t *testing.T) {
 		assert.Equal(t, 200, httpRes.StatusCode)
 		assert.NotEmpty(t, loginResp.LoginRedirectURI)
 
-		// 4) Obtain account holdings data
-		holdingsResp, httpRes, err := client.AccountInformationApi.GetAllUserHoldings(userId, *userSecret).Execute()
+		// 4) List the user's accounts
+		accountsResp, httpRes, err := client.AccountInformationApi.ListUserAccounts(userId, *userSecret).Execute()
 		require.Nil(t, err)
-		require.NotNil(t, holdingsResp)
+		require.NotNil(t, accountsResp)
 		assert.Equal(t, 200, httpRes.StatusCode)
 
 		// 5) Delete the user

--- a/sdks/java/src/test/java/com/snaptrade/client/GettingStartedTest.java
+++ b/sdks/java/src/test/java/com/snaptrade/client/GettingStartedTest.java
@@ -1,7 +1,6 @@
 package com.snaptrade.client;
 
 import com.snaptrade.client.model.Account;
-import com.snaptrade.client.model.AccountHoldings;
 import com.snaptrade.client.model.Brokerage;
 import com.snaptrade.client.model.DeleteUserResponse;
 import com.snaptrade.client.model.SnapTradeRegisterUserRequestBody;
@@ -52,12 +51,7 @@ public class GettingStartedTest {
                                 .execute();
                 System.out.println(response.get("redirectURI"));
 
-                // 5) Query holdings and available brokerages
-                List<AccountHoldings> holdings = snaptrade.accountInformation
-                                .getAllUserHoldings(userIDandSecret.getUserId(),
-                                                userIDandSecret.getUserSecret())
-                                .execute();
-                System.out.println(holdings);
+                // 5) Query accounts and available brokerages
                 List<Account> accounts = snaptrade.accountInformation.listUserAccounts(userIDandSecret.getUserId(),
                                 userIDandSecret.getUserSecret()).execute();
                 System.out.println(accounts);

--- a/sdks/php/test/GettingStartedTest.php
+++ b/sdks/php/test/GettingStartedTest.php
@@ -90,8 +90,8 @@ class GettingStartedTest extends TestCase
         );
         $user_id = getenv("SNAPTRADE_TEST_USER_ID");
         $user_secret = getenv("SNAPTRADE_TEST_USER_SECRET");
-        $holdings = $snaptrade->accountInformation->getAllUserHoldings($user_id, $user_secret);
-        $account_id = $holdings[0]->getAccount()->getId();
+        $accounts = $snaptrade->accountInformation->listUserAccounts($user_id, $user_secret);
+        $account_id = $accounts[0]->getId();
         $result = $snaptrade->trading->getUserAccountQuotes(
             user_id: $user_id,
             user_secret: $user_secret,

--- a/sdks/php7/test/GettingStartedTest.php
+++ b/sdks/php7/test/GettingStartedTest.php
@@ -91,8 +91,8 @@ class GettingStartedTest extends TestCase
         );
         $user_id = getenv("SNAPTRADE_TEST_USER_ID");
         $user_secret = getenv("SNAPTRADE_TEST_USER_SECRET");
-        $holdings = $snaptrade->accountInformation->getAllUserHoldings($user_id, $user_secret);
-        $account_id = $holdings[0]->getAccount()->getId();
+        $accounts = $snaptrade->accountInformation->listUserAccounts($user_id, $user_secret);
+        $account_id = $accounts[0]->getId();
         $result = $snaptrade->trading->getUserAccountQuotes(
             $user_id,
             $user_secret,

--- a/sdks/python/test/test_getting_started.py
+++ b/sdks/python/test/test_getting_started.py
@@ -28,7 +28,7 @@ def _commercial_client(**kwargs):
 
 
 class TestGettingStarted(unittest.TestCase):
-    """AccountHoldings unit test stubs"""
+    """Getting started integration tests."""
 
     def setUp(self):
         pass
@@ -65,11 +65,11 @@ class TestGettingStarted(unittest.TestCase):
         )
         print(redirect_uri.body)
 
-        # 5) Obtaining account holdings data
-        holdings = snaptrade.account_information.get_all_user_holdings(
+        # 5) List the user's accounts
+        accounts = snaptrade.account_information.list_user_accounts(
             user_id=user_id, user_secret=user_secret
         )
-        pprint(holdings.body)
+        pprint(accounts.body)
 
         # 6) Deleting a user
         deleted_response = snaptrade.authentication.delete_snap_trade_user(
@@ -104,12 +104,12 @@ class TestGettingStarted(unittest.TestCase):
         )
         print(redirect_uri.body)
 
-        # 5) Obtaining account holdings data
-        holdings = snaptrade.account_information.get_all_user_holdings(
+        # 5) List the user's accounts
+        accounts = snaptrade.account_information.list_user_accounts(
             user_id=user_id,
             user_secret=user_secret,
         )
-        pprint(holdings.body)
+        pprint(accounts.body)
 
         # 6) Deleting a user
         deleted_response = snaptrade.authentication.delete_snap_trade_user(
@@ -132,7 +132,7 @@ class TestGettingStarted(unittest.TestCase):
         )
         pprint(response.body)
 
-    def test_get_user_holdings(self):
+    def test_get_all_account_positions(self):
         snaptrade = _commercial_client()
         user_id = os.environ["SNAPTRADE_TEST_USER_ID"]
         user_secret = os.environ["SNAPTRADE_TEST_USER_SECRET"]
@@ -141,21 +141,27 @@ class TestGettingStarted(unittest.TestCase):
             user_secret=user_secret,
         )
         account_id = accounts.body[0]["id"]
-        holdings = snaptrade.account_information.get_user_holdings(
+        positions = snaptrade.account_information.get_all_account_positions(
             account_id=account_id,
             user_id=user_id,
             user_secret=user_secret,
         )
-        pprint(holdings)
+        pprint(positions.body)
 
-    def test_get_activities(self):
+    def test_get_account_activities(self):
         snaptrade = _commercial_client()
         user_id = os.environ["SNAPTRADE_TEST_USER_ID"]
         user_secret = os.environ["SNAPTRADE_TEST_USER_SECRET"]
+        accounts = snaptrade.account_information.list_user_accounts(
+            user_id=user_id,
+            user_secret=user_secret,
+        )
+        account_id = accounts.body[0]["id"]
         # instantiate two variables, one date that is 1 year ago and another that is today
         from_date = datetime.datetime.now() - datetime.timedelta(days=365)
         to_date = datetime.datetime.now()
-        response = snaptrade.transactions_and_reporting.get_activities(
+        response = snaptrade.account_information.get_account_activities(
+            account_id=account_id,
             user_id=user_id,
             user_secret=user_secret,
             start_date=from_date,
@@ -166,7 +172,8 @@ class TestGettingStarted(unittest.TestCase):
         # instantiate two variables of type "date", one date that is 1 year ago and another that is today
         from_date = datetime.date.today() - datetime.timedelta(days=365)
         to_date = datetime.date.today()
-        response = snaptrade.transactions_and_reporting.get_activities(
+        response = snaptrade.account_information.get_account_activities(
+            account_id=account_id,
             user_id=user_id,
             user_secret=user_secret,
             start_date=from_date,
@@ -179,7 +186,8 @@ class TestGettingStarted(unittest.TestCase):
             "%Y-%m-%d"
         )
         to_date = datetime.date.today().strftime("%Y-%m-%d")
-        response = snaptrade.transactions_and_reporting.get_activities(
+        response = snaptrade.account_information.get_account_activities(
+            account_id=account_id,
             user_id=user_id,
             user_secret=user_secret,
             start_date=from_date,
@@ -191,7 +199,8 @@ class TestGettingStarted(unittest.TestCase):
         # instantiate two variables of type "string" in ISO format, one date that is 1 year ago and another that is today
         from_date = (datetime.date.today() - datetime.timedelta(days=365)).isoformat()
         to_date = datetime.date.today().isoformat()
-        response = snaptrade.transactions_and_reporting.get_activities(
+        response = snaptrade.account_information.get_account_activities(
+            account_id=account_id,
             user_id=user_id,
             user_secret=user_secret,
             start_date=from_date,
@@ -208,9 +217,10 @@ class TestGettingStarted(unittest.TestCase):
         # print both from_date and to_date
         print(from_date)
         print(to_date)
-        # call the get_activities method and assert that an exception is thrown
+        # call the get_account_activities method and assert that an exception is thrown
         with self.assertRaises(Exception):
-            snaptrade.transactions_and_reporting.get_activities(
+            snaptrade.account_information.get_account_activities(
+                account_id=account_id,
                 user_id=user_id,
                 user_secret=user_secret,
                 start_date=from_date,

--- a/sdks/ruby/spec/getting_started_spec.rb
+++ b/sdks/ruby/spec/getting_started_spec.rb
@@ -63,9 +63,9 @@ describe 'GettingStarted' do
       redirect_uri = SnapTrade::Authentication.login_snap_trade_user(user_id: user_id, user_secret: response.user_secret)
       puts redirect_uri
 
-      # 5) Obtaining account holdings data
-      holdings = SnapTrade::AccountInformation.get_all_user_holdings(user_id: user_id, user_secret: response.user_secret)
-      puts holdings
+      # 5) List the user's accounts
+      accounts = SnapTrade::AccountInformation.list_user_accounts(user_id: user_id, user_secret: response.user_secret)
+      puts accounts
 
       # 6) Deleting a user
       deleted_response = SnapTrade::Authentication.delete_snap_trade_user(user_id: user_id)
@@ -95,9 +95,9 @@ describe 'GettingStarted' do
       redirect_uri = snaptrade.authentication.login_snap_trade_user(user_id: user_id, user_secret: response.user_secret)
       puts redirect_uri
 
-      # 5) Obtaining account holdings data
-      holdings = snaptrade.account_information.get_all_user_holdings(user_id: user_id, user_secret: response.user_secret)
-      puts holdings
+      # 5) List the user's accounts
+      accounts = snaptrade.account_information.list_user_accounts(user_id: user_id, user_secret: response.user_secret)
+      puts accounts
 
       # 6) Deleting a user
       deleted_response = snaptrade.authentication.delete_snap_trade_user(user_id: user_id)

--- a/sdks/typescript/index.test.ts
+++ b/sdks/typescript/index.test.ts
@@ -57,14 +57,14 @@ it("getting started", async () => {
   if (!("redirectURI" in data)) throw Error("Should have gotten redirect URI");
   console.log("redirectURI:", data.redirectURI);
 
-  // 5) Obtaining account holdings data
-  const holdings = (
-    await snaptrade.accountInformation.getAllUserHoldings({
+  // 5) List the user's accounts
+  const accounts = (
+    await snaptrade.accountInformation.listUserAccounts({
       userId,
       userSecret,
     })
   ).data;
-  console.log("holdings:", holdings);
+  console.log("accounts:", accounts);
 
   // 6) Deleting a user
   const deleteResponse = (
@@ -92,13 +92,19 @@ it("getUserAccountBalance", async () => {
   console.log(response.data);
 });
 
-it("getActivities", async () => {
+it("getAccountActivities", async () => {
   const snaptrade = new Snaptrade({
     auth: commercialAuth(),
   });
   const userId = process.env.SNAPTRADE_TEST_USER_ID as string;
   const userSecret = process.env.SNAPTRADE_TEST_USER_SECRET as string;
-  let activities = await snaptrade.transactionsAndReporting.getActivities({
+  const accounts = await snaptrade.accountInformation.listUserAccounts({
+    userId,
+    userSecret,
+  });
+  const accountId = accounts.data[0].id as string;
+  let activities = await snaptrade.accountInformation.getAccountActivities({
+    accountId,
     userId,
     userSecret,
   });
@@ -107,7 +113,8 @@ it("getActivities", async () => {
   // create two variables "startDate" and "endDate" that are strings representing 1 year ago and today in yyyy-mm-dd format using today's date
   const startDate = "2020-01-01";
   const endDate = "2020-12-31";
-  activities = await snaptrade.transactionsAndReporting.getActivities({
+  activities = await snaptrade.accountInformation.getAccountActivities({
+    accountId,
     userId,
     userSecret,
     startDate,
@@ -120,7 +127,8 @@ it("getActivities", async () => {
   // create variable startDate2 which is 1 year before endDate2
   const startDate2 = new Date(endDate2);
   startDate2.setFullYear(startDate2.getFullYear() - 1);
-  activities = await snaptrade.transactionsAndReporting.getActivities({
+  activities = await snaptrade.accountInformation.getAccountActivities({
+    accountId,
     userId,
     userSecret,
     startDate: startDate2,
@@ -130,7 +138,7 @@ it("getActivities", async () => {
   expect(activities).not.toBeNull();
 });
 
-it("getUserHoldings", async () => {
+it("getAllAccountPositions", async () => {
   const snaptrade = new Snaptrade({
     auth: commercialAuth(),
   });
@@ -140,12 +148,11 @@ it("getUserHoldings", async () => {
     userId,
     userSecret,
   });
-  const holdings = await snaptrade.accountInformation.getUserHoldings({
+  const positions = await snaptrade.accountInformation.getAllAccountPositions({
     userId,
     userSecret,
     accountId: accounts.data[0].id as string,
   });
-  // assert holdings is not null with jest
-  expect(holdings).not.toBeNull();
-  console.log(holdings.data);
+  expect(positions).not.toBeNull();
+  console.log(positions.data);
 });


### PR DESCRIPTION
## Summary

- migrate Konfig-ignored SDK tests from deprecated holdings and activities endpoints to `listUserAccounts`, `getAllAccountPositions`, and `getAccountActivities`
- replace legacy C# order cancellation coverage with `cancelOrder`
- remove stale ignored-test references to API groups and models that will disappear when the deprecated operations are removed from the OAS

## Why

Konfig preserves these ignored test files during SDK regeneration. Without this update, removing the deprecated operations from the OpenAPI specification would leave hand-maintained tests referencing generated methods and API groups that no longer exist.

## SDK behavior

- The Java, Go, and Ruby getting-started flows—and the general C#, Python, and TypeScript getting-started flows—create a new user without a connected brokerage account. They now call `listUserAccounts`; positions cannot be fetched until an account ID exists. Java already listed accounts, so its redundant holdings request was removed.
- Dedicated C#, Python, and TypeScript tests use the configured connected test account and migrate account-holdings coverage to `getAllAccountPositions`.
- PHP and PHP7 call `listUserAccounts` only to obtain the account ID required by their quote tests.

## Impact

This only changes ignored test and example coverage. It does not modify the OpenAPI specification or production SDK code.

## Validation

- ignored-test deprecated-reference audit: clean
- `npm run typecheck`
- `npm test -- --runInBand mock.test.ts signing.test.ts` (7 tests passed)
- C# net7 test-project build (existing generated-code warnings only)
- `mvn -q -DskipTests test`
- `python3 -m py_compile test/test_getting_started.py`
- `ruby -c spec/getting_started_spec.rb`

Go and PHP runtimes were not available locally; their changes reuse existing generated `listUserAccounts` interfaces already used in the same test files.