### PR TITLE
fix(ci): resolve manual regeneration PR explicitly

### DIFF
--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -127,6 +127,7 @@ jobs:
           HEAD_BRANCH: ${{ steps.manual.outputs.head_branch }}
         run: |
           prs=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
             --head "$HEAD_BRANCH" \
             --state open \
             --limit 2 \


### PR DESCRIPTION
## Summary

- pass the repository explicitly when resolving an existing manual regeneration PR
- allow the no-checkout manual path to query GitHub successfully

## Root cause

The existing-PR path skips checkout, but `gh pr list` relied on local Git repository context. The preparation job therefore failed before SDK generation with `fatal: not a git repository`.

## Validation

- parsed `regenerate-sdks.yaml` as YAML
- ran `git diff --check`
- verified `gh pr list --repo passiv/snaptrade-sdks` succeeds outside a Git worktree

`actionlint` is not installed locally.