### PR TITLE
ci: migrate workflows to Blacksmith

### DIFF
--- a/.github/workflows/openapi-lint.yaml
+++ b/.github/workflows/openapi-lint.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   lint:
     name: Lint OpenAPI specification
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -36,7 +36,7 @@ jobs:
   prepare:
     name: Prepare regeneration
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
       pull-requests: write
@@ -145,7 +145,7 @@ jobs:
   regenerate:
     name: Regenerate SDKs
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
       packages: read
@@ -209,7 +209,7 @@ jobs:
   test:
     name: Test ${{ matrix.language }} SDK
     needs: regenerate
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       matrix:
         language: [typescript, python, go, ruby, php, php7, csharp, java]
@@ -244,7 +244,7 @@ jobs:
       - prepare
       - regenerate
       - test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment:
       name: ${{ needs.prepare.outputs.merge_environment }}
       deployment: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   detect-changesets:
     name: Detect changesets
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       has_changesets: ${{ steps.changesets.outputs.has_changesets }}
     steps:
@@ -31,7 +31,7 @@ jobs:
     name: Bump SDK versions
     needs: detect-changesets
     if: needs.detect-changesets.outputs.has_changesets == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
       packages: read
@@ -103,7 +103,7 @@ jobs:
     name: Publish ${{ matrix.language }} SDK
     needs: detect-changesets
     if: needs.detect-changesets.outputs.has_changesets == 'false'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       actions: write
       artifact-metadata: write

--- a/.github/workflows/revalidate-portal.yaml
+++ b/.github/workflows/revalidate-portal.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   revalidate:
     name: Revalidate portal
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/slack-ci-failure-alert.yaml
+++ b/.github/workflows/slack-ci-failure-alert.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   notify-slack:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/sync-php-mirrors.yaml
+++ b/.github/workflows/sync-php-mirrors.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   prepare:
     name: Resolve PHP versions
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     outputs:
@@ -70,7 +70,7 @@ jobs:
   sync-php:
     name: Sync PHP mirror
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:
@@ -91,7 +91,7 @@ jobs:
   sync-php7:
     name: Sync PHP7 mirror
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

- run every active SDK workflow job on Blacksmith's 2-vCPU Ubuntu 24.04 runner
- cover linting, regeneration, SDK tests, release, publishing, PHP mirroring, portal revalidation, and Slack notifications
- preserve existing workflow behavior, permissions, containers, secrets, and actions

## Why

Move CI execution to Blacksmith without changing job capacity or workflow semantics, providing faster runners and colocated dependency caching.

## Validation

- `actionlint` 1.7.12 with the documented Blacksmith custom runner label
- `git diff --check`
- confirmed no active workflow remains on `ubuntu-latest`

## Rollout requirement

The Blacksmith GitHub App must have access to `passiv/snaptrade-sdks` before these jobs can be picked up.
