### PR TITLE
fix(ci): serialize SDK releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,10 @@ on:
       - templates/**
       - flows/**
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   detect-changesets:
     name: Detect changesets
@@ -141,6 +145,26 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Check whether SDK release tag exists
+        id: release-tag
+        env:
+          LANGUAGE: ${{ matrix.language }}
+        run: |
+          if [[ "$LANGUAGE" == "go" ]]; then
+            tag_pattern="refs/tags/sdks/go/v*"
+          else
+            tag_pattern="refs/tags/v*-$LANGUAGE"
+          fi
+
+          if git ls-remote --tags origin "$tag_pattern" |
+            awk -v sha="$GITHUB_SHA" '$1 == sha { found = 1 } END { exit !found }'
+          then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release tag for $LANGUAGE already exists on $GITHUB_SHA; publishing will be skipped."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install CLI
         uses: ./.github/actions/shared/install-cli
 
@@ -191,6 +215,7 @@ jobs:
           user: snaptrade
 
       - name: Publish SDK
+        if: steps.release-tag.outputs.exists != 'true'
         uses: nick-fields/retry@v4
         env:
           NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,26 +145,6 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Check whether SDK release tag exists
-        id: release-tag
-        env:
-          LANGUAGE: ${{ matrix.language }}
-        run: |
-          if [[ "$LANGUAGE" == "go" ]]; then
-            tag_pattern="refs/tags/sdks/go/v*"
-          else
-            tag_pattern="refs/tags/v*-$LANGUAGE"
-          fi
-
-          if git ls-remote --tags origin "$tag_pattern" |
-            awk -v sha="$GITHUB_SHA" '$1 == sha { found = 1 } END { exit !found }'
-          then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Release tag for $LANGUAGE already exists on $GITHUB_SHA; publishing will be skipped."
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install CLI
         uses: ./.github/actions/shared/install-cli
 
@@ -215,7 +195,6 @@ jobs:
           user: snaptrade
 
       - name: Publish SDK
-        if: steps.release-tag.outputs.exists != 'true'
         uses: nick-fields/retry@v4
         env:
           NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
## Summary

- serialize release workflow runs per Git ref
- keep the active release running while duplicate runs wait
- preserve the existing publication and republish handling

## Root cause

Two release runs started for the same version-bump commit. Both attempted to publish Java 5.1.0 concurrently, and Maven Central rejected the second deployment while the first was still being processed.

## Impact

Only one release for a branch can run at a time, preventing concurrent package deployments without adding language-specific tag logic.

## Validation

- `actionlint` 1.7.12
- `git diff --check`
