### PR TITLE
fix(ci): publish TypeScript on GitHub-hosted runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,7 +107,8 @@ jobs:
     name: Publish ${{ matrix.language }} SDK
     needs: detect-changesets
     if: needs.detect-changesets.outputs.has_changesets == 'false'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # npm provenance only supports GitHub-hosted runners.
+    runs-on: ${{ matrix.language == 'typescript' && 'ubuntu-latest' || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       actions: write
       artifact-metadata: write


### PR DESCRIPTION
## Summary

- run TypeScript publishing on `ubuntu-latest`
- keep all other SDK publishing jobs on Blacksmith

## Why

npm rejects provenance generated on self-hosted runners, causing the TypeScript 12.0.0 publish to fail with HTTP 422.

## Validation

- YAML syntax validation
- `git diff --check`

`actionlint` is not installed locally; PR checks will provide workflow validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/passiv/codesmith/snaptrade-sdks/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788980401&installation_model_id=425168&pr_number=902&repository=passiv%2Fsnaptrade-sdks&return_to=https%3A%2F%2Fgithub.com%2Fpassiv%2Fsnaptrade-sdks%2Fpull%2F902&signature=66eb7d305c7cb52c78c45fce355952295ab89ab2a496f876f6c21a478ebbf2a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->