### PR TITLE
fix(ci): skip auto-merge for manual SDK regeneration

### DIFF
--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -240,6 +240,7 @@ jobs:
 
   merge:
     name: Merge regenerated SDKs
+    if: github.event_name != 'workflow_dispatch'
     needs:
       - prepare
       - regenerate


### PR DESCRIPTION
## What changed

- Skip the Merge regenerated SDKs job for workflow_dispatch runs.
- Keep regeneration and the full SDK test matrix unchanged for manual runs.

## Why

Manual SDK regeneration currently reaches the same automatic PR merge job as pull-request-triggered regeneration. A manual run should generate and test SDK changes without merging the pull request.

## Validation

- Parsed regenerate-sdks.yaml successfully as YAML.
- Verified the manual-dispatch guard is present.
- git diff --check passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/passiv/codesmith/snaptrade-sdks/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789045288&installation_model_id=425168&pr_number=903&repository=passiv%2Fsnaptrade-sdks&return_to=https%3A%2F%2Fgithub.com%2Fpassiv%2Fsnaptrade-sdks%2Fpull%2F903&signature=cc5e990e3842e775e1e667afbf6e7bf403d95810088877ed0d073cd208aa7154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->