### PR TITLE
docs: document the Sandbox's non-equity holdings and the options gap

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -34,9 +34,10 @@ A simulated brokerage for exercising your integration end-to-end — connection 
 ## What the data covers (data scenarios)
 
 - Accounts, balances (cash + buying power), and positions across a handful of well-known tickers
+- Positions spanning **stocks**, an **ETF**, a **mutual fund**, a **money market fund** (returned with `cash_equivalent` set), and **crypto** — including fractional quantities, so you can exercise instrument-type and fractional-unit handling
 - Orders spanning every status — executed, partially filled, accepted, canceled, rejected
 - Transactions spanning **trades**, **cash & fees**, **dividends & income**, **corporate actions**, and **transfers** (see the full list of types below)
-- In the default **Self-directed** scenario these are **spread across the two accounts** (e.g. splits & dividends on one, transfers & mergers on the other) — iterate **all** accounts to see the full set
+- In the default **Self-directed** scenario these are **spread across the two accounts** (e.g. splits & dividends on the individual account, transfers & mergers on the IRA; crypto and the ETF on the individual account, the mutual fund and money market sweep on the IRA) — iterate **all** accounts to see the full set
 
 <details>
 <summary><b>All transaction types</b></summary>
@@ -79,4 +80,5 @@ These are the normalized `type` values SnapTrade maps real brokerage transaction
 ## Limitations
 
 - **Read-only** — placing/canceling trades isn't supported, and Sandbox won't appear in **trade-only** connection sessions
+- **No options yet** — the Sandbox returns no option positions, option orders, or `OPTION*` transactions
 - Data is **static and simulated** (timestamps are relative to the current time)


### PR DESCRIPTION
Follows the Sandbox guide added in #791.

Documents the non-equity holdings added in passiv/passiv#14322 — the Sandbox now returns an ETF, a mutual fund, a money market fund (with `cash_equivalent` set) and crypto alongside the equities, including fractional quantities.

Also adds an explicit **No options yet** limitation. Today the transaction-type table lists `OPTIONEXPIRATION` / `OPTIONASSIGNMENT` / `OPTIONEXERCISE`, but the Sandbox emits none of them and returns no option positions or orders — so the guide currently oversells it. Options are a planned follow-up; this line comes back out when they land.

Docs-only, no SDK or spec changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/passiv/codesmith/snaptrade-sdks/pr/909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789137588&installation_model_id=425168&pr_number=909&repository=passiv%2Fsnaptrade-sdks&return_to=https%3A%2F%2Fgithub.com%2Fpassiv%2Fsnaptrade-sdks%2Fpull%2F909&signature=d8078b6d96f4a2c809a06d1937cfb9293500f8773d7b83e4b5e384a7b3802cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->