### PR TITLE
docs: clarify per-account rate limit applies only to SnapTrade Personal

### DIFF
--- a/docs/ratelimiting.md
+++ b/docs/ratelimiting.md
@@ -5,9 +5,9 @@ The SnapTrade API uses rate limiting to protect against bursts of incoming traff
 There are two layers of rate limiting that may apply to your requests:
 
 1. **Customer-level rate limiting** -- a global limit across all requests from your `clientId`.
-2. **Account-level rate limiting** -- a [per-account](https://docs.snaptrade.com/docs/account-data) limit on specific account data endpoints.
+2. **Account-level rate limiting** -- a [per-account](https://docs.snaptrade.com/docs/account-data) limit on specific account data endpoints. This layer applies only to [SnapTrade Personal](https://docs.snaptrade.com/docs/personal-vs-commercial) users. Commercial users are subject to the customer-level limit only.
 
-A request must pass both layers. Even if you have remaining capacity at the customer level, you can still be throttled at the account level, and vice versa.
+A request must pass every layer that applies to you. For Personal users, even if you have remaining capacity at the customer level, you can still be throttled at the account level, and vice versa.
 
 When you exceed a rate limit, the API returns an HTTP status code `429` with a response body indicating how long to wait before retrying:
 
@@ -35,7 +35,7 @@ These are rolling limits that look at the trailing 60 seconds.
 
 In addition to the customer-level limit, the SnapTrade API enforces a **per-account** rate limit on endpoints that fetch account data. This limit is **10 requests per minute per account** by default.
 
-> **Note:** Account-level rate limiting is only enforced for **Personal** users. Commercial users are subject to the customer-level limit only. For more on the difference, see [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial).
+> **Note:** As noted above, account-level rate limiting is only enforced for **Personal** users. Commercial users are subject to the customer-level limit only. For more on the difference, see [SnapTrade Personal vs Commercial](https://docs.snaptrade.com/docs/personal-vs-commercial).
 
 Account-level rate limiting is scoped to the combination of your `clientId` and the `accountId` in the request URL. This means:
 


### PR DESCRIPTION
Surfaces the Personal-only scope of account-level rate limiting near the top of the rate limiting guide, where the two rate-limit layers are first introduced. Previously this caveat only appeared further down in the Account-Level Rate Limiting section, which could confuse commercial clients scanning the top of the guide. The existing note lower in the doc is retained but reworded to reinforce the point rather than repeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/passiv/codesmith/snaptrade-sdks/pr/910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789143944&installation_model_id=425168&pr_number=910&repository=passiv%2Fsnaptrade-sdks&return_to=https%3A%2F%2Fgithub.com%2Fpassiv%2Fsnaptrade-sdks%2Fpull%2F910&signature=46ccf5d6eccf57aa226081c34e55361bbf0043f24a814648c4425d2a2fb588da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->