### PR TITLE
Add Broker Access Guide under Troubleshooting

### DIFF
--- a/docs/broker-access-guide.md
+++ b/docs/broker-access-guide.md
@@ -1,0 +1,116 @@
+# Broker Access Guide
+
+Start building in minutes. The majority of SnapTrade's [brokerage integrations](https://docs.snaptrade.com/docs/integrations) are live the moment your [Production Access Application](https://dashboard.snaptrade.com/production-access) is approved. For the few brokers that work differently, this page breaks down exactly what to expect.
+
+The **free plan** includes up to 5 brokerage connections, with no additional steps required to access any integration.
+
+Brokerages become available on your production keys in one of three ways:
+
+1. Immediately
+2. After broker approval
+3. By bringing your own API keys
+
+## Available immediately
+
+These brokers are available to your users as soon as your SnapTrade Production Access Application is approved. Complete your profile, get approved, and start connecting.
+
+| Broker | Access Level |
+|---|---|
+| AJ Bell | Read Only |
+| Binance | Read and Trade |
+| BUX | Read Only |
+| Coinbase | Read and Trade |
+| CommSec | Read Only |
+| Degiro | Read Only |
+| E\*TRADE | Read and Trade |
+| eToro | Read Only |
+| Interactive Brokers | Read Only |
+| Kraken | Read and Trade |
+| Moomoo | Read and Trade |
+| Public | Read and Trade |
+| Questrade | Read Only |
+| Robinhood | Read Only |
+| Stake Australia | Read and Trade |
+| tastytrade | Read and Trade |
+| TD Direct Investing | Read Only |
+| Trading212 | Read and Trade |
+| Trading212 Practice | Read and Trade |
+| Upstox | Read Only |
+| Vanguard US | Read Only |
+| Wealthsimple | Read and Trade |
+| Webull CA | Read and Trade |
+| Webull US | Read and Trade |
+| Zerodha | Read Only |
+
+## Available after broker approval
+
+Some brokers require a production approval step before connections go live. Once your Production Access Application with SnapTrade is completed, we submit these applications automatically — no extra steps on your end. You'll just need to allow a few days for these to come online.
+
+| Broker | Access Level | Estimated Turnaround | Instructions | Status |
+|---|---|---|---|---|
+| Chase | Read Only | ~2 business days | Fill out app profile | Generally available |
+| Citi | Read Only | ~2 business days | Fill out app profile | Beta |
+| Edward Jones | Read Only | ~2 business days | Fill out app profile | Alpha |
+| Empower | Read Only | ~2 business days | Fill out app profile | Generally available |
+| Fidelity | Read Only | ~2 business days | Fill out app profile | Generally available |
+| PNC | Read Only | ~2 business days | Fill out app profile | Alpha |
+| Schwab | Read Only | ~1 week | Fill out app profile | Generally available |
+| TIAA | Read Only | ~2 weeks | Fill out app profile | Alpha |
+| Transamerica | Read Only | ~2 business days | Fill out app profile | Alpha |
+| US Bank | Read Only | ~1 week | Fill out app profile | Beta |
+| Wells Fargo | Read Only | ~2 business days | Fill out app profile | Generally available |
+
+## Bring your own API keys
+
+A small number of brokers require you to apply for API credentials directly with the broker. These are the only integrations where you'll need to take action beyond completing the Production Access Application. Once you have your keys, add them to your SnapTrade dashboard and you're good to go.
+
+Every broker in this section requires your own API keys. Use the table below to understand the steps needed for each.
+
+| Broker | Access Level | Estimated Turnaround |
+|---|---|---|
+| Schwab | Trading | Case-by-case basis |
+| Alpaca | Read and Trade | ~4 weeks |
+| TradeStation | Read and Trade | ~2 weeks |
+| Tradier | Read and Trade | ~2 weeks |
+
+### Schwab
+
+To enable Schwab OAuth with Trading access:
+
+1. Register for Accounts and Trading commercial access [on the Schwab developer portal](https://developer.schwab.com/products/trader-api--commercial).
+2. When prompted, set the callback URL to `https://connect.snaptrade.com/oauth/callback`.
+3. Once approved by Schwab, send your API keys securely to SnapTrade (for example, via Bitwarden) at [support@snaptrade.com](mailto:support@snaptrade.com).
+
+### Alpaca
+
+1. Go to [https://alpaca.markets/oauth](https://alpaca.markets/oauth) and click **Submit Your App**.
+2. Navigate to **Alpaca Connect > My Developed Apps > Submit Your App**.
+3. Complete the application form, setting the callback URL to `https://connect.snaptrade.com/oauth/alpaca`.
+4. After you submit, Alpaca generates your API key (Client ID and Secret).
+5. Send the keys securely to SnapTrade (for example, via Bitwarden) at [support@snaptrade.com](mailto:support@snaptrade.com).
+
+Note: Alpaca approval can take up to 30 days after keys are issued. Canadian developers are not supported at this time.
+
+### TradeStation
+
+1. Email [ClientExperience@tradestation.com](mailto:ClientExperience@tradestation.com) to request your API key, and ask that the callback URL be set to `https://connect.snaptrade.com/oauth/tradestation`.
+2. Once approved by TradeStation, send your API keys securely to SnapTrade (for example, via Bitwarden) at [support@snaptrade.com](mailto:support@snaptrade.com).
+
+Use the simulated trading environment for testing.
+
+### Tradier
+
+1. Sign up for Partner API access at [developer.tradier.com](https://developer.tradier.com/login).
+2. Reach out to Tradier's business development team and complete their partner survey.
+3. Set the callback URL to `https://connect.snaptrade.com/oauth/tradier`.
+4. Tradier will review your application and follow up directly.
+5. Once approved by Tradier, send your API keys securely to SnapTrade (for example, via Bitwarden) at [support@snaptrade.com](mailto:support@snaptrade.com).
+
+Notes:
+
+- Developers are charged a one-time fee of $500. Onboarding with Tradier is optional.
+- By default, Tradier access tokens expire after 24 hours. If you need users to remain connected without reauthorizing, request that refresh tokens be enabled for your application. This requires Tradier's approval — email [techsupport@tradier.com](mailto:techsupport@tradier.com) to start the process.
+
+## Next steps
+
+[Sign up for SnapTrade](https://dashboard.snaptrade.com/signup) and start connecting broker accounts today. If you have questions about a specific broker or integration, reach out to the SnapTrade team at [support@snaptrade.com](mailto:support@snaptrade.com).

--- a/konfig.yaml
+++ b/konfig.yaml
@@ -113,6 +113,8 @@ portal:
               path: docs/request-ids.md
             - id: fix-broken-connections
               path: docs/fix-broken-connections.md
+            - id: broker-access-guide
+              path: docs/broker-access-guide.md
             - id: faq
               path: docs/faq.md
             - id: sandbox


### PR DESCRIPTION
## What

Adds `docs/broker-access-guide.md` and registers it in the **Troubleshooting** group in `konfig.yaml`, after `fix-broken-connections`.

The guide covers how each brokerage becomes available on production keys, in three buckets:

1. **Available immediately** — live as soon as the Production Access Application is approved (25 brokers, with access level).
2. **Available after broker approval** — SnapTrade submits these automatically; table includes estimated turnaround and alpha/beta/GA status (11 brokers).
3. **Bring your own API keys** — Schwab, Alpaca, TradeStation, and Tradier, where the customer applies for credentials directly with the broker.

## Why

Customers regularly ask which brokers they can use right after approval and which need extra steps. This information lived only in an internal Notion page; this puts it on the docs site.

## Notes for reviewers

- Content is sourced from the internal Broker Access Guide. Broker names, access levels, turnarounds, statuses, callback URLs, and contact addresses are carried over as-is — worth a check that they're still current.
- The bring-your-own-keys instructions were dense multi-line table cells in the source. They're split into per-broker subsections with numbered steps; the summary table keeps only broker, access level, and turnaround. The "Requires own API keys?" column was dropped since every row was "Yes" — stated in prose instead.
- **Schwab appears twice**: Read Only in the broker-approval table, and Trading in the bring-your-own-keys table. Both are in the source and they are genuinely different access levels, but the guide doesn't explain the relationship between the two rows. Flagging in case we want a sentence clarifying it.
- The source Notion page ends with an embedded inline database that came back empty. If it holds broker data, it isn't reflected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/passiv/codesmith/snaptrade-sdks/pr/911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789162341&installation_model_id=425168&pr_number=911&repository=passiv%2Fsnaptrade-sdks&return_to=https%3A%2F%2Fgithub.com%2Fpassiv%2Fsnaptrade-sdks%2Fpull%2F911&signature=ff6a8d5f388efe177597dfc57fda37194c799387dbf9782a72329b48481eb3d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->