### PR TITLE
docs(trading): add order impact confirmation guide

### DIFF
--- a/docs/launching-your-application.md
+++ b/docs/launching-your-application.md
@@ -58,9 +58,9 @@ See [Ratelimiting](https://docs.snaptrade.com/docs/ratelimiting).
 
 ### 8. Trading
 
-If you're using trading functionality, you must have either clear user consent for automated trading or a trade preview flow that shows all expected fees and commissions. Users must also have the ability to opt out of SnapTrade functionality and delete their brokerage connection at any time. It’s recommended to not execute trades faster than 1 trade per connected account per second.
+If you're using trading functionality, you must have either clear user consent for automated trading or an order-confirmation flow that shows all available impact, fee, and commission information. Clearly identify estimates and unavailable values, and obtain the account owner's consent before proceeding without exact information. Users must also have the ability to opt out of SnapTrade functionality and delete their brokerage connection at any time. It’s recommended to not execute trades faster than 1 trade per connected account per second.
 
-See [Trading with SnapTrade](https://docs.snaptrade.com/docs/trading-with-snaptrade).
+See [Trading with SnapTrade](/docs/trading-with-snaptrade) and [Order impact and confirmation](/docs/order-impact-and-confirmation).
 
 ### 9. Webhooks
 

--- a/docs/order-impact-and-confirmation.md
+++ b/docs/order-impact-and-confirmation.md
@@ -1,0 +1,88 @@
+# Order Impact and Confirmation
+
+SnapTrade supports equity and option orders across institutions with different preview capabilities. A missing brokerage preview does not mean that an order cannot be placed: trading support and preview support are separate capabilities.
+
+In this guide, *order* means either an equity order or an option order unless a section says otherwise. Always confirm the institution's current asset, order, and preview support in the [SnapTrade Institution Support guide](https://support.snaptrade.com/brokerages).
+
+## Confirm every order
+
+Before submitting an order, present the available instructions and impact information clearly enough for the account owner to understand and consent to the order.
+
+The confirmation screen should include:
+
+- Institution and brokerage account
+- Security symbol, option contract, or option legs, as applicable
+- Order action for the order or each option leg
+- Quantity in shares, units, notional amount, or contracts
+- Order type
+- Limit price, stop price, or net debit or credit, when applicable
+- Time in force
+- Available cash-impact, commission, fee, and foreign-exchange estimates
+- Source of the impact information: brokerage preview, application-generated estimate, or not available
+- Clear disclosure describing unavailable values and the limits of any estimate
+- Explicit action through which the account owner confirms the order
+
+SnapTrade's [Application Compliance Policy](https://snaptrade.com/compliance-policy) requires applicable regulatory disclosures when an account owner issues trading instructions. If the execution price, fees, commissions, or cash impact are unknown or estimated, explain that clearly before the account owner confirms the order.
+
+## Identify the impact source
+
+The confirmation experience should distinguish the source of displayed values. Do not use the same label for brokerage-supplied data, an application calculation, and unavailable information.
+
+### Brokerage-supplied preview
+
+For supported equity orders, :api[Trading_getOrderImpact] checks the order without placing it. For supported option orders, :api[Trading_getOptionImpact] simulates an order with up to four legs. The response shape differs by workflow and institution.
+
+For option orders, available fields can include:
+
+- `estimated_cash_change`: estimated cash change before fees
+- `cash_change_direction`: whether the order results in a debit, credit, even result, or unknown result
+- `estimated_fee_total`: estimated transaction fees and commissions
+
+For equity orders, the preview can return estimated remaining cash, commission, and foreign-exchange fees. The application can combine these values with the order details when presenting estimated totals. All preview values are estimates, not guaranteed execution amounts.
+
+Recommended source label:
+
+> **Impact source: Brokerage preview**
+
+### Application-generated estimate
+
+When a brokerage does not expose a dedicated preview endpoint, an application can calculate a reasonable estimate from the latest available bid, ask, or last-trade quote; the order quantity or notional amount; current cash balances; currency-conversion assumptions; and any locally implemented commission or fee schedule.
+
+Recommended source label:
+
+> **Impact source: Application-generated estimate** — This application calculated these amounts using the latest available quote and fee assumptions. They were not supplied or verified by SnapTrade or the brokerage.
+
+### No reliable estimate
+
+If neither the brokerage nor the application can produce a reliable estimate, show the known order instructions and identify the missing values. Do not display unavailable fees or commissions as `$0.00`; zero can incorrectly suggest that no charges will apply.
+
+Recommended presentation:
+
+> **Estimated cash impact:** Not available
+>
+> **Estimated fees and commissions:** Not available
+
+## Recommended disclaimer language
+
+### Brokerage preview or application-generated estimate
+
+> **Estimated results.** The amounts shown are estimates only and are not guaranteed. The brokerage determines the final execution price, transaction amount, commissions, fees, and cash impact. Market orders can fill at a different price than the latest quote, and orders may partially fill or fill over multiple days. Exchange, ECN, regulatory, ADR, foreign-exchange, borrow, and other fees may apply, including when estimated commissions are `$0.00`.
+
+For an application-generated estimate, place the application-generated source label immediately before this disclaimer.
+
+### Impact information unavailable
+
+> **Order impact unavailable.** A reliable pre-trade impact or fee estimate is not available for this order. The final execution price, transaction amount, commissions, fees, and cash impact may not be known until the order is submitted or executed. Fees may apply. By submitting this order, you agree to proceed without these estimates.
+
+## Does unavailable impact prevent trading?
+
+No. Preview support and trading support are separate institution capabilities. The [SnapTrade trading workflow](/docs/trading-with-snaptrade) requires applications to validate order details in their own interface, but it does not make a brokerage preview a universal prerequisite for every equity or option order.
+
+Before enabling a workflow, verify that the institution supports:
+
+- Asset and symbol being traded
+- Requested order type and time in force
+- Fractional-unit or notional orders, when applicable
+- Single-leg or multi-leg options, when applicable
+- Intended option action and number of legs, when applicable
+- Any institution-specific permissions, account requirements, or limitations

--- a/docs/trading-with-snaptrade.md
+++ b/docs/trading-with-snaptrade.md
@@ -1,6 +1,6 @@
 # Trading with SnapTrade
 
-SnapTrade supports trading workflows for stocks, ETFs, other equities, options, and crypto. The exact feature set depends on the connected brokerage or exchange, so you should always [verify support](https://support.snaptrade.com/brokerages-table?v=e7bbcbf9f272441593f93decde660687) for the account you are about to trade with.
+SnapTrade supports trading workflows for stocks, ETFs, other equities, options, and crypto. The exact feature set depends on the connected brokerage or exchange, so you should always [verify support](https://support.snaptrade.com/brokerages) for the account you are about to trade with.
 
 > 🚧 **Soft Rate Limit**
 >
@@ -18,6 +18,12 @@ Most trading integrations with SnapTrade follow the same high-level flow:
 6. Monitor execution status.
 
 The sections below explain how that flow differs for equities, options, and crypto.
+
+## Confirm Order Details and Impact
+
+Before submitting an order, show the account owner the order instructions, all available impact and fee information, the source of any estimates, and a clear confirmation action. A brokerage preview is not available for every supported trading workflow and is not a universal prerequisite for placing an order.
+
+See [Order impact and confirmation](/docs/order-impact-and-confirmation) for confirmation requirements, recommended source labels and disclaimers, and guidance for orders without a reliable preview.
 
 ## Set Up Trading Access
 
@@ -132,6 +138,6 @@ In this example, the order buys `0.01` ETH with EUR.
 
 ## Brokerage Support and Reconciliation
 
-Not every brokerage supports every trading workflow. Extended-hours sessions, multi-leg options, and crypto trading are all institution-specific. Review the [SnapTrade Brokerage Support Matrix](https://support.snaptrade.com/brokerages-table?v=e7bbcbf9f272441593f93decde660687) before enabling a feature in production.
+Not every brokerage supports every trading workflow. Extended-hours sessions, multi-leg options, and crypto trading are all institution-specific. Review the [SnapTrade Institution Support guide](https://support.snaptrade.com/brokerages) before enabling a feature in production.
 
 After placing an order, we recommend you reconcile the latest state by pulling a list of recent orders with :api[AccountInformation_getUserAccountRecentOrders].

--- a/konfig.yaml
+++ b/konfig.yaml
@@ -61,6 +61,8 @@ portal:
               path: docs/implement-connection-portal.md
             - id: trading-with-snaptrade
               path: docs/trading-with-snaptrade.md
+            - id: order-impact-and-confirmation
+              path: docs/order-impact-and-confirmation.md
             - id: filtering-accounts-by-category
               path: docs/filtering-accounts-by-category.md
             - id: realtime-data


### PR DESCRIPTION
## Summary

- add a dedicated guide for confirming equity and option orders when brokerage previews are available, application-generated, or unavailable
- document recommended impact-source labels, confirmation fields, and disclaimer language
- link the guide from the main trading workflow and pre-launch checklist
- add the guide to the portal sidebar and update institution-support links

## Validation

- `git diff --check`
- parsed `konfig.yaml` with Ruby YAML
- verified referenced trading operation IDs exist in `api.yaml`
- verified current SnapTrade Institution Support and Application Compliance Policy guidance

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/passiv/codesmith/snaptrade-sdks/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789993274&installation_model_id=425168&pr_number=931&repository=passiv%2Fsnaptrade-sdks&return_to=https%3A%2F%2Fgithub.com%2Fpassiv%2Fsnaptrade-sdks%2Fpull%2F931&signature=cb1d36cb8dd06dd89219457269a8097372ee4641003aab3acda046e5a491c453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->