### PR TITLE
Remove early-access gating from OAuth app guide

### DIFF
--- a/docs/oauth-apps.md
+++ b/docs/oauth-apps.md
@@ -35,16 +35,16 @@ OAuth currently supports account data and connection-management workflows under 
 
 You need:
 
-- An eligible Commercial Pay-as-you-go SnapTrade account with OAuth app registration enabled.
+- A Commercial SnapTrade account.
 - An app backend that can keep a client secret and refresh tokens confidential.
 - At least one redirect URI. Production redirects must use HTTPS; local testing can use `http://localhost`, `http://127.0.0.1`, or `http://[::1]`.
-- A SnapTrade Personal test account with Personal OAuth enabled and at least one brokerage connection. During early access, contact [support@snaptrade.com](mailto:support@snaptrade.com) to enable a test account.
+- A SnapTrade Personal account/workspace with at least one brokerage connection, for testing the consent flow.
 
 The self-serve OAuth app created in the SnapTrade Dashboard is a **confidential client**. Do not embed its client secret in browser JavaScript, a mobile app, a desktop app, or a distributed CLI. Those clients should send the authorization result to a backend that performs the token exchange and stores tokens securely.
 
 ## 1. Register Your App
 
-In the [SnapTrade Dashboard](https://dashboard.snaptrade.com), open **Settings**, select **OAuth App**, and add your callback URLs. During early access, each eligible developer account can register one OAuth app. The app name shown during consent comes from the name of your SnapTrade customer account.
+In the [SnapTrade Dashboard](https://dashboard.snaptrade.com), open **Settings**, select **OAuth App**, and add your callback URLs. Each developer account can register one OAuth app. The app name shown during consent comes from the name of your SnapTrade customer account.
 
 To receive webhooks, also configure a listener URL in the **Webhooks** section of the Dashboard. OAuth apps registered under the same SnapTrade customer use that customer's existing webhook URL, signing key, and custom headers. The `oauthClientId` in each OAuth webhook identifies the receiving app.
 
@@ -249,7 +249,7 @@ await fetch(revocationEndpoint, {
 
 1. Register a loopback callback such as `http://127.0.0.1:3000/oauth/snaptrade/callback` alongside your production callback.
 2. If testing webhooks, expose a local listener through an HTTPS tunnel and configure that public URL in the **Webhooks** section of the Dashboard.
-3. Use a separate SnapTrade Personal test account instead of the developer account that owns the OAuth app.
+3. Use a SnapTrade Personal workspace as the test user granting access to your app.
 4. Connect the SnapTrade Sandbox brokerage or a test brokerage connection from the SnapTrade Dashboard.
 5. Run the authorization flow with `scope=read webhook` and confirm the consent page shows both permissions.
 6. Exchange the code from your backend and call `GET /accounts` with only the Bearer token.
@@ -276,4 +276,4 @@ await fetch(revocationEndpoint, {
 - Explain what brokerage data your app uses and link to a privacy policy.
 - Do not describe OAuth as supporting trading until a trading scope is available to your app.
 
-The OAuth preview is the best time to start building: access is free, the integration is smaller than a traditional Commercial implementation, and early apps can give direct feedback on the platform. When your integration is ready, contact SnapTrade to discuss production access and app discovery eligibility.
+The OAuth preview is the best time to start building: access is free, the integration is smaller than a traditional Commercial implementation, and early apps can give direct feedback on the platform. When your integration is ready, contact SnapTrade to discuss app discovery eligibility.


### PR DESCRIPTION
## What changed

Updates `docs/oauth-apps.md` to reflect that OAuth is generally available: any Commercial customer can register an OAuth app, and Personal users can grant OAuth access without special enablement.

- **Before You Start**: first bullet is now just "A Commercial SnapTrade account", dropping "eligible", "Pay-as-you-go", and "with OAuth app registration enabled". The Personal test account bullet no longer says "Personal OAuth enabled" or tells readers to email support during early access.
- **Register Your App**: removed "During early access" and "eligible". The one-app-per-developer-account limit is kept.
- **Test Locally**: step 3 no longer says to use a separate Personal account, since a Personal workspace under the same Dashboard login works for testing the consent flow.
- **Closing paragraph**: no longer says production access requires contacting SnapTrade. App discovery eligibility is still mentioned.

## Why

The early-access qualifiers described a gated rollout that no longer exists. Phrases like "with OAuth app registration enabled" read as feature flags the reader cannot see or act on.

## Reviewer notes

Two things were left as written and are worth a quick confirmation: the one-OAuth-app-per-account limit in step 1, and the "Limited-time free preview" pricing callout at the top of the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/passiv/codesmith/snaptrade-sdks/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791470173&installation_model_id=425168&pr_number=948&repository=passiv%2Fsnaptrade-sdks&return_to=https%3A%2F%2Fgithub.com%2Fpassiv%2Fsnaptrade-sdks%2Fpull%2F948&signature=03d1d13019a63d883d49851c0d720e31db5b0a62c5a0d0c8ff169672754b37c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->